### PR TITLE
Simplify RemoteFundingEntityManager

### DIFF
--- a/Civi/Funding/Api4/Action/Remote/ApplicationProcess/AbstractFormAction.php
+++ b/Civi/Funding/Api4/Action/Remote/ApplicationProcess/AbstractFormAction.php
@@ -108,7 +108,9 @@ abstract class AbstractFormAction extends AbstractRemoteFundingAction {
 
     /** @phpstan-var applicationProcessT|null $applicationProcessValues */
     $applicationProcessValues = $this->_remoteFundingEntityManager->getById(
-      'FundingApplicationProcess', $applicationProcessId, $this->remoteContactId, $this->getContactId()
+      'FundingApplicationProcess',
+      $applicationProcessId,
+      $this->remoteContactId,
     );
     Assert::notNull($applicationProcessValues,
       sprintf('Application process with ID %d not found', $applicationProcessId));
@@ -119,7 +121,6 @@ abstract class AbstractFormAction extends AbstractRemoteFundingAction {
       FundingCase::_getEntityName(),
       $applicationProcess->getFundingCaseId(),
       $this->remoteContactId,
-      $this->getContactId(),
     );
     Assert::notNull($fundingCaseValues,
       sprintf('Funding case with ID %d not found', $applicationProcess->getFundingCaseId()));
@@ -130,7 +131,6 @@ abstract class AbstractFormAction extends AbstractRemoteFundingAction {
       FundingCaseType::_getEntityName(),
       $fundingCase->getFundingCaseTypeId(),
       $this->remoteContactId,
-      $this->getContactId(),
     );
     Assert::notNull($fundingCaseTypeValues, sprintf('Funding case type with ID %d not found', $fundingCase->getId()));
     $fundingCaseType = FundingCaseTypeEntity::fromArray($fundingCaseTypeValues);
@@ -140,7 +140,6 @@ abstract class AbstractFormAction extends AbstractRemoteFundingAction {
       FundingProgram::_getEntityName(),
       $fundingCase->getFundingProgramId(),
       $this->remoteContactId,
-      $this->getContactId()
     );
     Assert::notNull($fundingProgramValues,
       sprintf('Funding program with ID %d not found', $fundingCase->getFundingProgramId()));

--- a/Civi/Funding/Api4/Action/Remote/FundingCase/AbstractNewApplicationFormAction.php
+++ b/Civi/Funding/Api4/Action/Remote/FundingCase/AbstractNewApplicationFormAction.php
@@ -86,7 +86,6 @@ abstract class AbstractNewApplicationFormAction extends AbstractRemoteFundingAct
       FundingCaseType::_getEntityName(),
       $fundingCaseTypeId,
       $this->remoteContactId,
-      $this->getContactId(),
     );
     Assert::notNull($fundingCaseTypeValues, sprintf('Funding case type with ID %d not found', $fundingCaseTypeId));
     $fundingCaseType = FundingCaseTypeEntity::fromArray($fundingCaseTypeValues);
@@ -96,7 +95,6 @@ abstract class AbstractNewApplicationFormAction extends AbstractRemoteFundingAct
       FundingProgram::_getEntityName(),
       $fundingProgramId,
       $this->remoteContactId,
-      $this->getContactId()
     );
     Assert::notNull($fundingProgramValues, sprintf('Funding program with ID %d not found', $fundingProgramId));
     $fundingProgram = FundingProgramEntity::fromArray($fundingProgramValues);

--- a/Civi/Funding/Remote/RemoteFundingEntityManagerInterface.php
+++ b/Civi/Funding/Remote/RemoteFundingEntityManagerInterface.php
@@ -26,11 +26,11 @@ interface RemoteFundingEntityManagerInterface {
    *
    * @throws \API_Exception
    */
-  public function getById(string $entity, int $id, string $remoteContactId, int $contactId): ?array;
+  public function getById(string $entity, int $id, string $remoteContactId): ?array;
 
   /**
    * @throws \API_Exception
    */
-  public function hasAccess(string $entity, int $id, string $remoteContactId, int $contactId): bool;
+  public function hasAccess(string $entity, int $id, string $remoteContactId): bool;
 
 }

--- a/tests/phpunit/Civi/Funding/Api4/Action/Remote/ApplicationProcess/AbstractFormActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/Remote/ApplicationProcess/AbstractFormActionTest.php
@@ -84,10 +84,10 @@ abstract class AbstractFormActionTest extends TestCase {
     ];
 
     $this->remoteFundingEntityManagerMock->method('getById')->willReturnMap([
-      ['FundingApplicationProcess', 22, static::REMOTE_CONTACT_ID, static::CONTACT_ID, $this->applicationProcessValues],
-      ['FundingCase', 33, static::REMOTE_CONTACT_ID, static::CONTACT_ID, $this->fundingCaseValues],
-      ['FundingCaseType', 44, static::REMOTE_CONTACT_ID, static::CONTACT_ID, $this->fundingCaseTypeValues],
-      ['FundingProgram', 55, static::REMOTE_CONTACT_ID, static::CONTACT_ID, $this->fundingProgramValues],
+      ['FundingApplicationProcess', 22, static::REMOTE_CONTACT_ID, $this->applicationProcessValues],
+      ['FundingCase', 33, static::REMOTE_CONTACT_ID, $this->fundingCaseValues],
+      ['FundingCaseType', 44, static::REMOTE_CONTACT_ID, $this->fundingCaseTypeValues],
+      ['FundingProgram', 55, static::REMOTE_CONTACT_ID, $this->fundingProgramValues],
     ]);
   }
 

--- a/tests/phpunit/Civi/Funding/Api4/Action/Remote/FundingCase/AbstractNewApplicationFormActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/Remote/FundingCase/AbstractNewApplicationFormActionTest.php
@@ -75,8 +75,8 @@ abstract class AbstractNewApplicationFormActionTest extends TestCase {
     ];
 
     $this->remoteFundingEntityManagerMock->method('getById')->willReturnMap([
-      ['FundingCaseType', 22, '00', 11, &$this->fundingCaseTypeValues],
-      ['FundingProgram', 33, '00', 11, &$this->fundingProgramValues],
+      ['FundingCaseType', 22, '00', &$this->fundingCaseTypeValues],
+      ['FundingProgram', 33, '00', &$this->fundingProgramValues],
     ]);
   }
 

--- a/tests/phpunit/Civi/Funding/Remote/RemoteFundingEntityManagerTest.php
+++ b/tests/phpunit/Civi/Funding/Remote/RemoteFundingEntityManagerTest.php
@@ -85,7 +85,7 @@ final class RemoteFundingEntityManagerTest extends TestCase {
         'remoteContactId' => '00',
       ])->willReturn($apiResult);
 
-    static::assertSame($record, $this->entityManager->getById('RemoteFoo', 11, '00', 2));
+    static::assertSame($record, $this->entityManager->getById('RemoteFoo', 11, '00'));
   }
 
   public function testGetByIdNotFound(): void {
@@ -100,7 +100,7 @@ final class RemoteFundingEntityManagerTest extends TestCase {
         'remoteContactId' => '00',
       ])->willReturn($apiResult);
 
-    static::assertNull($this->entityManager->getById('RemoteFoo', 11, '00', 2));
+    static::assertNull($this->entityManager->getById('RemoteFoo', 11, '00'));
   }
 
   public function testGetByIdNonRemote(): void {
@@ -129,7 +129,7 @@ final class RemoteFundingEntityManagerTest extends TestCase {
     $this->api4Mock->expects(static::exactly(2))->method('execute')
       ->willReturnMap($valueMap);
 
-    static::assertSame($record, $this->entityManager->getById('Foo', 11, '00', 2));
+    static::assertSame($record, $this->entityManager->getById('Foo', 11, '00'));
   }
 
   public function testGetByIdNonRemoteWithContactId(): void {
@@ -151,19 +151,19 @@ final class RemoteFundingEntityManagerTest extends TestCase {
     $this->api4Mock->expects(static::once())->method('execute')
       ->willReturnMap($valueMap);
 
-    static::assertSame($record, $this->entityManager->getById('Foo', 11, '00', 2));
+    static::assertSame($record, $this->entityManager->getById('Foo', 11, '00'));
   }
 
   public function testGetByIdInvalidEntity(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Unknown entity "Foo"');
-    $this->entityManager->getById('Foo', 11, '00', 2);
+    $this->entityManager->getById('Foo', 11, '00');
   }
 
   public function testGetByIdInvalidRemoteEntity(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Unknown entity "RemoteFoo"');
-    $this->entityManager->getById('RemoteFoo', 11, '00', 2);
+    $this->entityManager->getById('RemoteFoo', 11, '00');
   }
 
   public function testHasAccessTrue(): void {
@@ -176,7 +176,7 @@ final class RemoteFundingEntityManagerTest extends TestCase {
       ->with('RemoteFoo', 'get', ['select' => ['id'], 'where' => [['id', '=', 11]], 'remoteContactId' => '00'])
       ->willReturn($apiResult);
 
-    static::assertTrue($this->entityManager->hasAccess('RemoteFoo', 11, '00', 2));
+    static::assertTrue($this->entityManager->hasAccess('RemoteFoo', 11, '00'));
   }
 
   public function testHasAccessFalse(): void {
@@ -188,7 +188,7 @@ final class RemoteFundingEntityManagerTest extends TestCase {
       ->with('RemoteFoo', 'get', ['select' => ['id'], 'where' => [['id', '=', 11]], 'remoteContactId' => '00'])
       ->willReturn($apiResult);
 
-    static::assertFalse($this->entityManager->hasAccess('RemoteFoo', 11, '00', 2));
+    static::assertFalse($this->entityManager->hasAccess('RemoteFoo', 11, '00'));
   }
 
   public function testHasAccessNonRemote(): void {
@@ -202,7 +202,7 @@ final class RemoteFundingEntityManagerTest extends TestCase {
       ->with('Foo', 'get', ['select' => ['id'], 'where' => [['id', '=', 11]]])
       ->willReturn($apiResult);
 
-    static::assertTrue($this->entityManager->hasAccess('Foo', 11, '00', 2));
+    static::assertTrue($this->entityManager->hasAccess('Foo', 11, '00'));
   }
 
   public function testHasAccessNonRemoteWithContactId(): void {
@@ -216,19 +216,19 @@ final class RemoteFundingEntityManagerTest extends TestCase {
       ->with('Foo', 'get', ['select' => ['id'], 'where' => [['id', '=', 11]]])
       ->willReturn($apiResult);
 
-    static::assertTrue($this->entityManager->hasAccess('Foo', 11, '00', 2));
+    static::assertTrue($this->entityManager->hasAccess('Foo', 11, '00'));
   }
 
   public function testHasAccessInvalidEntity(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Unknown entity "Foo"');
-    $this->entityManager->hasAccess('Foo', 11, '00', 2);
+    $this->entityManager->hasAccess('Foo', 11, '00');
   }
 
   public function testHasAccessInvalidRemoteEntity(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Unknown entity "RemoteFoo"');
-    $this->entityManager->hasAccess('RemoteFoo', 11, '00', 2);
+    $this->entityManager->hasAccess('RemoteFoo', 11, '00');
   }
 
   private function addMockAction(string $entity, string $actionName, AbstractAction $action): self {


### PR DESCRIPTION
With the contact ID being part of the session now, it is not required in
RemoteFundingEntityManager.