### PR TITLE
ContactChecker: Use equal comparison instead of check for identity

### DIFF
--- a/Civi/Funding/Permission/ContactRelation/Checker/ContactChecker.php
+++ b/Civi/Funding/Permission/ContactRelation/Checker/ContactChecker.php
@@ -31,7 +31,9 @@ final class ContactChecker implements ContactRelationCheckerInterface {
    * @inheritDoc
    */
   public function hasRelation(int $contactId, string $relationType, array $relationProperties): bool {
-    return $contactId === $relationProperties['contactId'];
+    // Input fields with "crm-entityref" return the IDs as strings, so we have
+    // to compare for equality instead of identity.
+    return $contactId == $relationProperties['contactId'];
   }
 
   public function supportsRelationType(string $relationType): bool {

--- a/tests/phpunit/Civi/Funding/Fixtures/FundingCaseContactRelationFixture.php
+++ b/tests/phpunit/Civi/Funding/Fixtures/FundingCaseContactRelationFixture.php
@@ -31,7 +31,9 @@ final class FundingCaseContactRelationFixture {
    * @throws \API_Exception
    */
   public static function addContact(int $contactId, int $fundingCaseId, array $permissions): array {
-    return self::addFixture($fundingCaseId, 'Contact', ['contactId' => $contactId], $permissions);
+    // Contact IDs are stored as string (see comment in ContactChecker), so we
+    // do the same here.
+    return self::addFixture($fundingCaseId, 'Contact', ['contactId' => (string) $contactId], $permissions);
   }
 
   /**

--- a/tests/phpunit/Civi/Funding/Fixtures/FundingProgramContactRelationFixture.php
+++ b/tests/phpunit/Civi/Funding/Fixtures/FundingProgramContactRelationFixture.php
@@ -31,7 +31,9 @@ final class FundingProgramContactRelationFixture {
    * @throws \API_Exception
    */
   public static function addContact(int $contactId, int $fundingProgramId, array $permissions): array {
-    return self::addFixture($fundingProgramId, 'Contact', ['contactId' => $contactId], $permissions);
+    // Contact IDs are stored as string (see comment in ContactChecker), so we
+    // do the same here.
+    return self::addFixture($fundingProgramId, 'Contact', ['contactId' => (string) $contactId], $permissions);
   }
 
   /**


### PR DESCRIPTION
Input fields with `crm-entityref` return IDs as strings instead of integers.