### PR TITLE
FundingProgramManager: Allow empty record permissions when loading a funding program by id

### DIFF
--- a/Civi/Funding/Api4/Action/FundingProgram/GetAction.php
+++ b/Civi/Funding/Api4/Action/FundingProgram/GetAction.php
@@ -37,6 +37,8 @@ final class GetAction extends DAOGetAction {
 
   private FundingSessionInterface $session;
 
+  private bool $allowEmptyRecordPermissions = FALSE;
+
   public function __construct(CiviEventDispatcherInterface $eventDispatcher,
     PossiblePermissionsLoaderInterface $possiblePermissionsLoader,
     FundingSessionInterface $session
@@ -45,6 +47,22 @@ final class GetAction extends DAOGetAction {
     $this->_eventDispatcher = $eventDispatcher;
     $this->_possiblePermissionsLoader = $possiblePermissionsLoader;
     $this->session = $session;
+  }
+
+  public function isAllowEmptyRecordPermissions(): bool {
+    return $this->allowEmptyRecordPermissions;
+  }
+
+  /**
+   * @param bool $allowEmptyRecordPermissions
+   *   If TRUE, records without permissions are not filtered from result.
+   *
+   * @return $this
+   */
+  public function setAllowEmptyRecordPermissions(bool $allowEmptyRecordPermissions): self {
+    $this->allowEmptyRecordPermissions = $allowEmptyRecordPermissions;
+
+    return $this;
   }
 
   /**

--- a/Civi/Funding/FundingProgram/FundingProgramManager.php
+++ b/Civi/Funding/FundingProgram/FundingProgramManager.php
@@ -46,10 +46,13 @@ class FundingProgramManager {
   }
 
   /**
+   * This method also returns a funding program if a user has no permissions.
+   *
    * @throws \CRM_Core_Exception
    */
   public function get(int $id): ?FundingProgramEntity {
     $action = FundingProgram::get(FALSE)
+      ->setAllowEmptyRecordPermissions(TRUE)
       ->addWhere('id', '=', $id);
 
     /** @var fundingProgramT|null $values */

--- a/Civi/RemoteTools/Api4/Action/Helper/AddPermissionsToRecords.php
+++ b/Civi/RemoteTools/Api4/Action/Helper/AddPermissionsToRecords.php
@@ -46,12 +46,16 @@ final class AddPermissionsToRecords {
     $this->getRecordPermissions = $getRecordPermissions;
   }
 
-  public function __invoke(Result $result): void {
+  /**
+   * @param bool $allowEmptyPermissions
+   *   Records without permissions are filtered from result, if not TRUE.
+   */
+  public function __invoke(Result $result, bool $allowEmptyPermissions = FALSE): void {
     $records = [];
     /** @phpstan-var array<string, mixed>&array{id: int} $record */
     foreach ($result as $record) {
       $record['permissions'] = $permissions = ($this->getRecordPermissions)($record);
-      if ([] === $permissions) {
+      if ([] === $permissions && !$allowEmptyPermissions) {
         continue;
       }
 

--- a/Civi/RemoteTools/Api4/Action/Traits/PermissionsGetActionTrait.php
+++ b/Civi/RemoteTools/Api4/Action/Traits/PermissionsGetActionTrait.php
@@ -49,7 +49,7 @@ trait PermissionsGetActionTrait {
       $this->getPossiblePermissions(),
       fn (array $record) => $this->getRecordPermissions($record)
     );
-    ($this->_addPermissionsToRecords)($result);
+    ($this->_addPermissionsToRecords)($result, $this->isAllowEmptyRecordPermissions());
 
     if ($countSelectedOnly) {
       $result->setCountMatched($result->count());
@@ -83,6 +83,14 @@ trait PermissionsGetActionTrait {
    */
   protected function getFieldsRequiredToGetPermissions(): array {
     return ['id'];
+  }
+
+  /**
+   * @return bool
+   *   Records without permissions are filtered from result, if not TRUE.
+   */
+  protected function isAllowEmptyRecordPermissions(): bool {
+    return FALSE;
   }
 
   private function isFieldSelected(string $field): bool {

--- a/tests/phpunit/Civi/Api4/FundingProgramTest.php
+++ b/tests/phpunit/Civi/Api4/FundingProgramTest.php
@@ -26,6 +26,7 @@ namespace Civi\Api4;
 use Civi\Api4\Traits\FundingProgramTestFixturesTrait;
 use Civi\Funding\AbstractFundingHeadlessTestCase;
 use Civi\Funding\Api4\Permissions;
+use Civi\Funding\Fixtures\ContactFixture;
 use Civi\Funding\Util\SessionTestUtil;
 
 /**
@@ -95,6 +96,14 @@ final class FundingProgramTest extends AbstractFundingHeadlessTestCase {
     $notPermittedResult = FundingProgram::get()
       ->execute();
     static::assertSame(0, $notPermittedResult->rowCount);
+
+    // Unrelated contact has access, if empty permissions are allowed.
+    $unrelatedContact = ContactFixture::addIndividual();
+    SessionTestUtil::mockInternalRequestSession($unrelatedContact['id']);
+    static::assertCount(2, FundingProgram::get()
+      ->setAllowEmptyRecordPermissions(TRUE)
+      ->execute(),
+    );
   }
 
   public function testPermissionsRemote(): void {

--- a/tests/phpunit/Civi/Api4/RemoteFundingCaseTest.php
+++ b/tests/phpunit/Civi/Api4/RemoteFundingCaseTest.php
@@ -77,20 +77,6 @@ final class RemoteFundingCaseTest extends AbstractRemoteFundingHeadlessTestCase 
 
     FundingCaseTypeProgramFixture::addFixture($fundingCaseType->getId(), $fundingProgram->getId());
 
-    // No permission
-    $e = NULL;
-    try {
-      RemoteFundingCase::getNewApplicationForm()
-        ->setRemoteContactId((string) $contact['id'])
-        ->setFundingCaseTypeId($fundingCaseType->getId())
-        ->setFundingProgramId($fundingProgram->getId())
-        ->execute();
-    }
-    catch (\Exception $e) {
-      static::assertSame(sprintf('Funding program with ID "%d" not found', $fundingProgram->getId()), $e->getMessage());
-    }
-    static::assertNotNull($e);
-
     // No "application_create" permission
     FundingProgramContactRelationFixture::addContact($contact['id'], $fundingProgram->getId(), ['application_test']);
     $e = NULL;

--- a/tests/phpunit/Civi/Funding/FundingProgram/FundingProgramManagerTest.php
+++ b/tests/phpunit/Civi/Funding/FundingProgram/FundingProgramManagerTest.php
@@ -66,6 +66,7 @@ final class FundingProgramManagerTest extends AbstractContainerMockedTestCase {
     $this->api4Mock->expects(static::exactly(2))->method('executeAction')->withConsecutive(
       [
         static::callback(function (GetAction $action) {
+          static::assertTrue($action->isAllowEmptyRecordPermissions());
           static::assertSame([['id', '=', 13, FALSE]], $action->getWhere());
 
           return TRUE;
@@ -73,6 +74,7 @@ final class FundingProgramManagerTest extends AbstractContainerMockedTestCase {
       ],
       [
         static::callback(function (GetAction $action) {
+          static::assertTrue($action->isAllowEmptyRecordPermissions());
           static::assertSame([['id', '=', 12, FALSE]], $action->getWhere());
 
           return TRUE;


### PR DESCRIPTION
This is required to get the currency when a user has access to a funding case, but no permission on the related funding program.