### PR TITLE
Mock method getParamInfo() of API actions in unit tests

### DIFF
--- a/Civi/Funding/Api4/Action/FundingCase/ApproveAction.php
+++ b/Civi/Funding/Api4/Action/FundingCase/ApproveAction.php
@@ -36,7 +36,7 @@ use Webmozart\Assert\Assert;
  * @method $this setId(int $id)
  * @method $this setTitle(string $title)
  */
-final class ApproveAction extends AbstractAction {
+class ApproveAction extends AbstractAction {
 
   /**
    * @var int

--- a/Civi/Funding/Api4/Action/FundingCase/GetPossibleActionsAction.php
+++ b/Civi/Funding/Api4/Action/FundingCase/GetPossibleActionsAction.php
@@ -32,7 +32,7 @@ use Webmozart\Assert\Assert;
 /**
  * @method $this setId(int $id)
  */
-final class GetPossibleActionsAction extends AbstractAction {
+class GetPossibleActionsAction extends AbstractAction {
 
   /**
    * @var int

--- a/Civi/Funding/Api4/Action/FundingCase/RecreateTransferContractAction.php
+++ b/Civi/Funding/Api4/Action/FundingCase/RecreateTransferContractAction.php
@@ -33,7 +33,7 @@ use Webmozart\Assert\Assert;
 /**
  * @method $this setId(int $id)
  */
-final class RecreateTransferContractAction extends AbstractAction {
+class RecreateTransferContractAction extends AbstractAction {
 
   /**
    * @var int

--- a/Civi/Funding/Api4/Action/FundingCaseTypeProgram/GetRelationAction.php
+++ b/Civi/Funding/Api4/Action/FundingCaseTypeProgram/GetRelationAction.php
@@ -27,7 +27,7 @@ use Civi\Api4\Generic\Result;
  * @method int getFundingCaseTypeId()
  * @method int getFundingProgramId()
  */
-final class GetRelationAction extends AbstractAction {
+class GetRelationAction extends AbstractAction {
 
   /**
    * @var int

--- a/Civi/Funding/Api4/Action/FundingDrawdown/AcceptAction.php
+++ b/Civi/Funding/Api4/Action/FundingDrawdown/AcceptAction.php
@@ -29,7 +29,7 @@ use Webmozart\Assert\Assert;
 /**
  * @method $this setId(int $int)
  */
-final class AcceptAction extends AbstractAction {
+class AcceptAction extends AbstractAction {
 
   /**
    * @var int

--- a/Civi/Funding/Api4/Action/FundingDrawdown/RejectAction.php
+++ b/Civi/Funding/Api4/Action/FundingDrawdown/RejectAction.php
@@ -32,7 +32,7 @@ use Webmozart\Assert\Assert;
 /**
  * @method $this setId(int $int)
  */
-final class RejectAction extends AbstractAction {
+class RejectAction extends AbstractAction {
 
   /**
    * @var int

--- a/Civi/Funding/Api4/Action/Remote/ApplicationProcess/GetFormAction.php
+++ b/Civi/Funding/Api4/Action/Remote/ApplicationProcess/GetFormAction.php
@@ -30,7 +30,7 @@ use Webmozart\Assert\Assert;
 /**
  * @method $this setApplicationProcessId(int $applicationProcessId)
  */
-final class GetFormAction extends AbstractFormAction {
+class GetFormAction extends AbstractFormAction {
 
   /**
    * @var int

--- a/Civi/Funding/Api4/Action/Remote/ApplicationProcess/SubmitFormAction.php
+++ b/Civi/Funding/Api4/Action/Remote/ApplicationProcess/SubmitFormAction.php
@@ -29,7 +29,7 @@ use Webmozart\Assert\Assert;
 /**
  * @method $this setData(array $data)
  */
-final class SubmitFormAction extends AbstractFormAction {
+class SubmitFormAction extends AbstractFormAction {
 
   /**
    * @var array

--- a/Civi/Funding/Api4/Action/Remote/ApplicationProcess/ValidateFormAction.php
+++ b/Civi/Funding/Api4/Action/Remote/ApplicationProcess/ValidateFormAction.php
@@ -30,7 +30,7 @@ use Webmozart\Assert\Assert;
 /**
  * @method $this setData(array $data)
  */
-final class ValidateFormAction extends AbstractFormAction {
+class ValidateFormAction extends AbstractFormAction {
 
   /**
    * @var array

--- a/Civi/Funding/Api4/Action/Remote/FundingCase/GetNewApplicationFormAction.php
+++ b/Civi/Funding/Api4/Action/Remote/FundingCase/GetNewApplicationFormAction.php
@@ -34,7 +34,7 @@ use Webmozart\Assert\Assert;
  * @method $this setFundingProgramId(int $fundingProgramId)
  * @method $this setFundingCaseTypeId(int $fundingCaseTypeId)
  */
-final class GetNewApplicationFormAction extends AbstractNewApplicationFormAction {
+class GetNewApplicationFormAction extends AbstractNewApplicationFormAction {
 
   use NewApplicationFormActionTrait;
 

--- a/Civi/Funding/Api4/Action/Remote/FundingCase/SubmitNewApplicationFormAction.php
+++ b/Civi/Funding/Api4/Action/Remote/FundingCase/SubmitNewApplicationFormAction.php
@@ -31,7 +31,7 @@ use Webmozart\Assert\Assert;
 /**
  * @method $this setData(array $data)
  */
-final class SubmitNewApplicationFormAction extends AbstractNewApplicationFormAction {
+class SubmitNewApplicationFormAction extends AbstractNewApplicationFormAction {
 
   /**
    * @var array

--- a/Civi/Funding/Api4/Action/Remote/FundingCase/ValidateNewApplicationFormAction.php
+++ b/Civi/Funding/Api4/Action/Remote/FundingCase/ValidateNewApplicationFormAction.php
@@ -31,7 +31,7 @@ use Webmozart\Assert\Assert;
 /**
  * @method $this setData(array $data)
  */
-final class ValidateNewApplicationFormAction extends AbstractNewApplicationFormAction {
+class ValidateNewApplicationFormAction extends AbstractNewApplicationFormAction {
 
   /**
    * @var array

--- a/Civi/Funding/Api4/Action/Remote/FundingProgram/GetRelatedAction.php
+++ b/Civi/Funding/Api4/Action/Remote/FundingProgram/GetRelatedAction.php
@@ -32,7 +32,7 @@ use Civi\RemoteTools\Api4\Action\Traits\EventActionTrait;
  * @method void setId(int $id)
  * @method void setType(string $type)
  */
-final class GetRelatedAction extends AbstractAction implements RemoteFundingActionInterface {
+class GetRelatedAction extends AbstractAction implements RemoteFundingActionInterface {
 
   use EventActionTrait;
 

--- a/tests/phpunit/Civi/Funding/Api4/Action/FundingCase/ApproveActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/FundingCase/ApproveActionTest.php
@@ -29,6 +29,7 @@ use Civi\Funding\FundingCase\Handler\FundingCaseApproveHandlerInterface;
 use Civi\Funding\FundingCase\TransferContractRouter;
 use Civi\Funding\FundingProgram\FundingCaseTypeManager;
 use Civi\Funding\FundingProgram\FundingProgramManager;
+use Civi\Funding\Traits\CreateMockTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -36,6 +37,8 @@ use PHPUnit\Framework\TestCase;
  * @covers \Civi\Funding\Api4\Action\FundingCase\ApproveAction
  */
 final class ApproveActionTest extends TestCase {
+
+  use CreateMockTrait;
 
   private ApproveAction $action;
 
@@ -71,7 +74,8 @@ final class ApproveActionTest extends TestCase {
     $this->fundingCaseTypeManagerMock = $this->createMock(FundingCaseTypeManager::class);
     $this->fundingProgramManagerMock = $this->createMock(FundingProgramManager::class);
     $this->transferContractRouterMock = $this->createMock(TransferContractRouter::class);
-    $this->action = new ApproveAction(
+    $this->action = $this->createApi4ActionMock(
+      ApproveAction::class,
       $this->approveHandlerMock,
       $this->fundingCaseManagerMock,
       $this->fundingCaseTypeManagerMock,

--- a/tests/phpunit/Civi/Funding/Api4/Action/FundingCase/GetPossibleActionsActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/FundingCase/GetPossibleActionsActionTest.php
@@ -26,6 +26,7 @@ use Civi\Funding\FundingCase\Command\FundingCasePossibleActionsGetCommand;
 use Civi\Funding\FundingCase\FundingCaseManager;
 use Civi\Funding\FundingCase\Handler\FundingCasePossibleActionsGetHandlerInterface;
 use Civi\Funding\FundingProgram\FundingCaseTypeManager;
+use Civi\Funding\Traits\CreateMockTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -33,6 +34,8 @@ use PHPUnit\Framework\TestCase;
  * @covers \Civi\Funding\Api4\Action\FundingCase\GetPossibleActionsAction
  */
 final class GetPossibleActionsActionTest extends TestCase {
+
+  use CreateMockTrait;
 
   private GetPossibleActionsAction $action;
 
@@ -56,7 +59,8 @@ final class GetPossibleActionsActionTest extends TestCase {
     $this->fundingCaseManagerMock = $this->createMock(FundingCaseManager::class);
     $this->fundingCaseTypeManagerMock = $this->createMock(FundingCaseTypeManager::class);
     $this->possibleActionsGetHandlerMock = $this->createMock(FundingCasePossibleActionsGetHandlerInterface::class);
-    $this->action = new GetPossibleActionsAction(
+    $this->action = $this->createApi4ActionMock(
+      GetPossibleActionsAction::class,
       $this->fundingCaseManagerMock,
       $this->fundingCaseTypeManagerMock,
       $this->possibleActionsGetHandlerMock,

--- a/tests/phpunit/Civi/Funding/Api4/Action/FundingCase/RecreateTransferContractActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/FundingCase/RecreateTransferContractActionTest.php
@@ -28,6 +28,7 @@ use Civi\Funding\FundingCase\FundingCaseManager;
 use Civi\Funding\FundingCase\Handler\TransferContractRecreateHandlerInterface;
 use Civi\Funding\FundingProgram\FundingCaseTypeManager;
 use Civi\Funding\FundingProgram\FundingProgramManager;
+use Civi\Funding\Traits\CreateMockTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -35,6 +36,8 @@ use PHPUnit\Framework\TestCase;
  * @covers \Civi\Funding\Api4\Action\FundingCase\RecreateTransferContractAction
  */
 final class RecreateTransferContractActionTest extends TestCase {
+
+  use CreateMockTrait;
 
   private RecreateTransferContractAction $action;
 
@@ -65,7 +68,8 @@ final class RecreateTransferContractActionTest extends TestCase {
     $this->fundingCaseTypeManagerMock = $this->createMock(FundingCaseTypeManager::class);
     $this->fundingProgramManagerMock = $this->createMock(FundingProgramManager::class);
     $this->transferContractRecreateHandlerMock = $this->createMock(TransferContractRecreateHandlerInterface::class);
-    $this->action = new RecreateTransferContractAction(
+    $this->action = $this->createApi4ActionMock(
+      RecreateTransferContractAction::class,
       $this->fundingCaseManagerMock,
       $this->fundingCaseTypeManagerMock,
       $this->fundingProgramManagerMock,

--- a/tests/phpunit/Civi/Funding/Api4/Action/FundingCaseTypeProgram/GetRelationActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/FundingCaseTypeProgram/GetRelationActionTest.php
@@ -47,7 +47,7 @@ final class GetRelationActionTest extends TestCase {
     parent::setUp();
     $this->getActionMock = $this->createMockWithExtraMethods(BasicGetAction::class, ['setDebug']);
     $this->getActionMock->method('getEntityName')->willReturn('TestEntity');
-    $this->action = new GetRelationAction($this->getActionMock);
+    $this->action = $this->createApi4ActionMock(GetRelationAction::class, $this->getActionMock);
   }
 
   public function testRun(): void {

--- a/tests/phpunit/Civi/Funding/Api4/Action/FundingDrawdown/AcceptActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/FundingDrawdown/AcceptActionTest.php
@@ -23,12 +23,15 @@ use Civi\Api4\Generic\Result;
 use Civi\Funding\EntityFactory\DrawdownFactory;
 use Civi\Funding\Mock\Session\TestFundingSession;
 use Civi\Funding\PayoutProcess\DrawdownManager;
+use Civi\Funding\Traits\CreateMockTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Civi\Funding\Api4\Action\FundingDrawdown\AcceptAction
  */
 final class AcceptActionTest extends TestCase {
+
+  use CreateMockTrait;
 
   private AcceptAction $action;
 
@@ -40,7 +43,8 @@ final class AcceptActionTest extends TestCase {
   protected function setUp(): void {
     parent::setUp();
     $this->drawdownManagerMock = $this->createMock(DrawdownManager::class);
-    $this->action = new AcceptAction(
+    $this->action = $this->createApi4ActionMock(
+      AcceptAction::class,
       $this->drawdownManagerMock,
       TestFundingSession::newInternal(2),
     );

--- a/tests/phpunit/Civi/Funding/Api4/Action/FundingDrawdown/RejectActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/FundingDrawdown/RejectActionTest.php
@@ -27,6 +27,7 @@ use Civi\Funding\EntityFactory\PayoutProcessFactory;
 use Civi\Funding\FundingCase\FundingCaseManager;
 use Civi\Funding\PayoutProcess\DrawdownManager;
 use Civi\Funding\PayoutProcess\PayoutProcessManager;
+use Civi\Funding\Traits\CreateMockTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -34,6 +35,8 @@ use PHPUnit\Framework\TestCase;
  * @covers \Civi\Funding\Api4\Action\FundingDrawdown\RejectAction
  */
 final class RejectActionTest extends TestCase {
+
+  use CreateMockTrait;
 
   /**
    * @var \Civi\Funding\Api4\Action\FundingDrawdown\RejectAction
@@ -60,7 +63,8 @@ final class RejectActionTest extends TestCase {
     $this->drawdownManagerMock = $this->createMock(DrawdownManager::class);
     $this->fundingCaseManagerMock = $this->createMock(FundingCaseManager::class);
     $this->payoutProcessManagerMock = $this->createMock(PayoutProcessManager::class);
-    $this->action = new RejectAction(
+    $this->action = $this->createApi4ActionMock(
+      RejectAction::class,
       $this->drawdownManagerMock,
       $this->fundingCaseManagerMock,
       $this->payoutProcessManagerMock,

--- a/tests/phpunit/Civi/Funding/Api4/Action/Remote/ApplicationProcess/GetFormActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/Remote/ApplicationProcess/GetFormActionTest.php
@@ -26,6 +26,7 @@ namespace Civi\Funding\Api4\Action\Remote\ApplicationProcess;
 use Civi\Api4\Generic\Result;
 use Civi\Funding\Event\Remote\ApplicationProcess\GetApplicationFormEvent;
 use Civi\Funding\Exception\FundingException;
+use Civi\Funding\Traits\CreateMockTrait;
 use Civi\RemoteTools\Form\JsonForms\JsonFormsElement;
 use Civi\RemoteTools\Form\JsonSchema\JsonSchema;
 
@@ -36,11 +37,14 @@ use Civi\RemoteTools\Form\JsonSchema\JsonSchema;
  */
 final class GetFormActionTest extends AbstractFormActionTest {
 
+  use CreateMockTrait;
+
   private GetFormAction $action;
 
   protected function setUp(): void {
     parent::setUp();
-    $this->action = new GetFormAction(
+    $this->action = $this->createApi4ActionMock(
+      GetFormAction::class,
       $this->applicationProcessBundleLoaderMock,
       $this->eventDispatcherMock
     );

--- a/tests/phpunit/Civi/Funding/Api4/Action/Remote/ApplicationProcess/SubmitFormActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/Remote/ApplicationProcess/SubmitFormActionTest.php
@@ -26,6 +26,7 @@ namespace Civi\Funding\Api4\Action\Remote\ApplicationProcess;
 use Civi\Api4\Generic\Result;
 use Civi\Funding\Event\Remote\ApplicationProcess\SubmitApplicationFormEvent;
 use Civi\Funding\Exception\FundingException;
+use Civi\Funding\Traits\CreateMockTrait;
 use Civi\RemoteTools\Form\JsonForms\JsonFormsElement;
 use Civi\RemoteTools\Form\JsonSchema\JsonSchema;
 use Civi\RemoteTools\Form\RemoteForm;
@@ -37,6 +38,8 @@ use Civi\RemoteTools\Form\RemoteForm;
  */
 final class SubmitFormActionTest extends AbstractFormActionTest {
 
+  use CreateMockTrait;
+
   private SubmitFormAction $action;
 
   /**
@@ -46,7 +49,8 @@ final class SubmitFormActionTest extends AbstractFormActionTest {
 
   protected function setUp(): void {
     parent::setUp();
-    $this->action = new SubmitFormAction(
+    $this->action = $this->createApi4ActionMock(
+      SubmitFormAction::class,
       $this->applicationProcessBundleLoaderMock,
       $this->eventDispatcherMock
     );

--- a/tests/phpunit/Civi/Funding/Api4/Action/Remote/ApplicationProcess/ValidateFormActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/Remote/ApplicationProcess/ValidateFormActionTest.php
@@ -26,6 +26,7 @@ namespace Civi\Funding\Api4\Action\Remote\ApplicationProcess;
 use Civi\Api4\Generic\Result;
 use Civi\Funding\Event\Remote\ApplicationProcess\ValidateApplicationFormEvent;
 use Civi\Funding\Exception\FundingException;
+use Civi\Funding\Traits\CreateMockTrait;
 
 /**
  * @covers \Civi\Funding\Api4\Action\Remote\ApplicationProcess\ValidateFormAction
@@ -33,6 +34,8 @@ use Civi\Funding\Exception\FundingException;
  * @covers \Civi\Funding\Event\Remote\AbstractFundingValidateFormEvent
  */
 final class ValidateFormActionTest extends AbstractFormActionTest {
+
+  use CreateMockTrait;
 
   private ValidateFormAction $action;
 
@@ -43,7 +46,8 @@ final class ValidateFormActionTest extends AbstractFormActionTest {
 
   protected function setUp(): void {
     parent::setUp();
-    $this->action = new ValidateFormAction(
+    $this->action = $this->createApi4ActionMock(
+      ValidateFormAction::class,
       $this->applicationProcessBundleLoaderMock,
       $this->eventDispatcherMock
     );

--- a/tests/phpunit/Civi/Funding/Api4/Action/Remote/FundingCase/GetNewApplicationFormActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/Remote/FundingCase/GetNewApplicationFormActionTest.php
@@ -27,6 +27,7 @@ use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Generic\Result;
 use Civi\Funding\Event\Remote\FundingCase\GetNewApplicationFormEvent;
 use Civi\Funding\Exception\FundingException;
+use Civi\Funding\Traits\CreateMockTrait;
 use Civi\RemoteTools\Form\JsonForms\JsonFormsElement;
 use Civi\RemoteTools\Form\JsonSchema\JsonSchema;
 
@@ -37,11 +38,14 @@ use Civi\RemoteTools\Form\JsonSchema\JsonSchema;
  */
 final class GetNewApplicationFormActionTest extends AbstractNewApplicationFormActionTest {
 
+  use CreateMockTrait;
+
   private GetNewApplicationFormAction $action;
 
   protected function setUp(): void {
     parent::setUp();
-    $this->action = new GetNewApplicationFormAction(
+    $this->action = $this->createApi4ActionMock(
+      GetNewApplicationFormAction::class,
       $this->fundingCaseTypeManagerMock,
       $this->fundingProgramManagerMock,
       $this->eventDispatcherMock,

--- a/tests/phpunit/Civi/Funding/Api4/Action/Remote/FundingCase/SubmitNewApplicationFormActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/Remote/FundingCase/SubmitNewApplicationFormActionTest.php
@@ -27,6 +27,7 @@ use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Generic\Result;
 use Civi\Funding\Event\Remote\FundingCase\SubmitNewApplicationFormEvent;
 use Civi\Funding\Exception\FundingException;
+use Civi\Funding\Traits\CreateMockTrait;
 use Civi\RemoteTools\Form\JsonForms\JsonFormsElement;
 use Civi\RemoteTools\Form\JsonSchema\JsonSchema;
 use Civi\RemoteTools\Form\RemoteForm;
@@ -38,6 +39,8 @@ use Civi\RemoteTools\Form\RemoteForm;
  */
 final class SubmitNewApplicationFormActionTest extends AbstractNewApplicationFormActionTest {
 
+  use CreateMockTrait;
+
   private SubmitNewApplicationFormAction $action;
 
   /**
@@ -47,7 +50,8 @@ final class SubmitNewApplicationFormActionTest extends AbstractNewApplicationFor
 
   protected function setUp(): void {
     parent::setUp();
-    $this->action = new SubmitNewApplicationFormAction(
+    $this->action = $this->createApi4ActionMock(
+      SubmitNewApplicationFormAction::class,
       $this->fundingCaseTypeManagerMock,
       $this->fundingProgramManagerMock,
       $this->eventDispatcherMock,

--- a/tests/phpunit/Civi/Funding/Api4/Action/Remote/FundingCase/ValidateNewApplicationFormActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/Remote/FundingCase/ValidateNewApplicationFormActionTest.php
@@ -28,6 +28,7 @@ use Civi\Api4\Generic\Result;
 use Civi\Funding\Api4\Action\Remote\FundingCase\Traits\NewApplicationFormActionTrait;
 use Civi\Funding\Event\Remote\FundingCase\ValidateNewApplicationFormEvent;
 use Civi\Funding\Exception\FundingException;
+use Civi\Funding\Traits\CreateMockTrait;
 use Symfony\Bridge\PhpUnit\ClockMock;
 
 /**
@@ -36,6 +37,8 @@ use Symfony\Bridge\PhpUnit\ClockMock;
  * @covers \Civi\Funding\Event\Remote\AbstractFundingValidateFormEvent
  */
 final class ValidateNewApplicationFormActionTest extends AbstractNewApplicationFormActionTest {
+
+  use CreateMockTrait;
 
   private ValidateNewApplicationFormAction $action;
 
@@ -53,7 +56,8 @@ final class ValidateNewApplicationFormActionTest extends AbstractNewApplicationF
 
   protected function setUp(): void {
     parent::setUp();
-    $this->action = new ValidateNewApplicationFormAction(
+    $this->action = $this->createApi4ActionMock(
+      ValidateNewApplicationFormAction::class,
       $this->fundingCaseTypeManagerMock,
       $this->fundingProgramManagerMock,
       $this->eventDispatcherMock,

--- a/tests/phpunit/Civi/Funding/Api4/Action/Remote/FundingProgram/GetRelatedActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/Remote/FundingProgram/GetRelatedActionTest.php
@@ -27,6 +27,7 @@ namespace Civi\Funding\Api4\Action\Remote\FundingProgram;
 use Civi\Api4\Generic\Result;
 use Civi\Core\CiviEventDispatcherInterface;
 use Civi\Funding\Event\Remote\FundingDAOGetEvent;
+use Civi\Funding\Traits\CreateMockTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -34,6 +35,8 @@ use PHPUnit\Framework\TestCase;
  * @covers \Civi\Funding\Api4\Action\Remote\FundingProgram\GetRelatedAction
  */
 final class GetRelatedActionTest extends TestCase {
+
+  use CreateMockTrait;
 
   /**
    * @var \PHPUnit\Framework\MockObject\MockObject&\Civi\Core\CiviEventDispatcherInterface
@@ -45,7 +48,7 @@ final class GetRelatedActionTest extends TestCase {
   protected function setUp(): void {
     parent::setUp();
     $this->eventDispatcherMock = $this->createMock(CiviEventDispatcherInterface::class);
-    $this->action = new GetRelatedAction($this->eventDispatcherMock);
+    $this->action = $this->createApi4ActionMock(GetRelatedAction::class, $this->eventDispatcherMock);
   }
 
   public function testRun(): void {

--- a/tests/phpunit/Civi/Funding/Traits/CreateMockTrait.php
+++ b/tests/phpunit/Civi/Funding/Traits/CreateMockTrait.php
@@ -30,6 +30,24 @@ use PHPUnit\Framework\MockObject\MockObject;
 trait CreateMockTrait {
 
   /**
+   * Creates an APIv4 action mock that behaves (mostly) like the mocked class
+   * itself. However, getParamInfo() is mocked because otherwise option
+   * callbacks would be called that (might) require a complete Civi env.
+   *
+   * @template RealInstanceType of \Civi\Api4\Generic\AbstractAction
+   * @phpstan-param class-string<RealInstanceType> $className
+   * @phpstan-param mixed ...$constructorArgs
+   *
+   * @return \PHPUnit\Framework\MockObject\MockObject&RealInstanceType
+   */
+  public function createApi4ActionMock(string $className, ...$constructorArgs): MockObject {
+    return $this->getMockBuilder($className)
+      ->onlyMethods(['getParamInfo'])
+      ->setConstructorArgs($constructorArgs)
+      ->getMock();
+  }
+
+  /**
    * @template RealInstanceType of object
    * @param class-string<RealInstanceType> $originalClassName
    * @param array<string> $extraMethods


### PR DESCRIPTION
Otherwise option callbacks would be called that (might) require a complete Civi env.