### PR TITLE
AVK1: Put currency in label instead of suffix

### DIFF
--- a/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1FahrtkostenUiSchema.php
+++ b/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1FahrtkostenUiSchema.php
@@ -28,20 +28,14 @@ final class AVK1FahrtkostenUiSchema extends JsonFormsGroup {
     $elements = [
       new JsonFormsControl(
         '#/properties/kosten/properties/fahrtkosten/properties/intern',
-        'Interne Fahrtkosten',
-        NULL,
-        NULL,
-        $currency
+        'Interne Fahrtkosten in ' . $currency,
       ),
       new JsonFormsControl(
         '#/properties/kosten/properties/fahrtkosten/properties/anTeilnehmerErstattet',
-        'An Teilnehmer*innen erstattete Fahrtkosten',
-        NULL,
-        NULL,
-        $currency
+        'An Teilnehmer*innen erstattete Fahrtkosten in ' . $currency
       ),
       new JsonFormsControl('#/properties/kosten/properties/fahrtkostenGesamt',
-        'Fahrtkosten gesamt', NULL, NULL, $currency),
+        'Fahrtkosten gesamt in ' . $currency),
     ];
 
     parent::__construct(

--- a/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1HonorareUiSchema.php
+++ b/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1HonorareUiSchema.php
@@ -31,16 +31,16 @@ final class AVK1HonorareUiSchema extends JsonFormsGroup {
       new JsonFormsArray('#/properties/kosten/properties/honorare', '', NULL, [
         new JsonFormsHidden('#/properties/_identifier'),
         new JsonFormsControl('#/properties/stunden', 'Stunden'),
-        new JsonFormsControl('#/properties/verguetung', 'Vergütung', NULL, NULL, $currency),
+        new JsonFormsControl('#/properties/verguetung', 'Vergütung in ' . $currency),
         new JsonFormsControl('#/properties/leistung', 'Vereinbarte Leistung'),
         new JsonFormsControl('#/properties/qualifikation', 'Qualifikation der Honorarkraft'),
-        new JsonFormsControl('#/properties/betrag', 'Betrag', NULL, NULL, $currency),
+        new JsonFormsControl('#/properties/betrag', 'Betrag in ' . $currency),
       ], [
         'addButtonLabel' => 'Honorar hinzufügen',
         'removeButtonLabel' => 'Honorar entfernen',
       ]),
-      new JsonFormsControl('#/properties/kosten/properties/honorareGesamt', 'Honorarkosten gesamt',
-        NULL, NULL, $currency),
+      new JsonFormsControl('#/properties/kosten/properties/honorareGesamt',
+        'Honorarkosten gesamt in ' . $currency),
     ];
 
     parent::__construct(

--- a/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1OeffentlicheMittelUiSchema.php
+++ b/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1OeffentlicheMittelUiSchema.php
@@ -27,11 +27,11 @@ final class AVK1OeffentlicheMittelUiSchema extends JsonFormsGroup {
   public function __construct(string $currency) {
     $elements = [
       new JsonFormsControl('#/properties/finanzierung/properties/oeffentlicheMittel/properties/europa',
-        'Finanzierung durch Europa-Mittel', NULL, NULL, $currency),
+        'Finanzierung durch Europa-Mittel in ' . $currency),
       new JsonFormsControl('#/properties/finanzierung/properties/oeffentlicheMittel/properties/bundeslaender',
-        'Finanzierung durch Städte und Kreise', NULL, NULL, $currency),
+        'Finanzierung durch Bundesländer in ' . $currency),
       new JsonFormsControl('#/properties/finanzierung/properties/oeffentlicheMittel/properties/staedteUndKreise',
-        'Städte und Kreise', NULL, NULL, $currency),
+        'Finanzierung durch Städte und Kreise in ' . $currency),
     ];
 
     parent::__construct(

--- a/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1SachkostenUiSchema.php
+++ b/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1SachkostenUiSchema.php
@@ -34,14 +34,14 @@ final class AVK1SachkostenUiSchema extends JsonFormsGroup {
         [
           new JsonFormsHidden('#/properties/_identifier'),
           new JsonFormsControl('#/properties/gegenstand', 'Gegenstand'),
-          new JsonFormsControl('#/properties/betrag', 'Betrag', NULL, NULL, $currency),
+          new JsonFormsControl('#/properties/betrag', 'Betrag in ' . $currency),
         ], [
           'addButtonLabel' => 'Sachkosten hinzufügen',
           'removeButtonLabel' => 'Sachkosten entfernen',
         ]
       ),
       new JsonFormsControl('#/properties/kosten/properties/sachkostenGesamt',
-        'Sachkosten gesamt', NULL, NULL, $currency),
+        'Sachkosten gesamt in ' . $currency),
     ];
 
     parent::__construct(

--- a/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1SonstigeAusgabenUiSchema.php
+++ b/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1SonstigeAusgabenUiSchema.php
@@ -30,14 +30,14 @@ final class AVK1SonstigeAusgabenUiSchema extends JsonFormsGroup {
     $elements = [
       new JsonFormsArray('#/properties/kosten/properties/sonstigeAusgaben', '', NULL, [
         new JsonFormsHidden('#/properties/_identifier'),
-        new JsonFormsControl('#/properties/betrag', 'Betrag', NULL, NULL, $currency),
+        new JsonFormsControl('#/properties/betrag', 'Betrag in ' . $currency),
         new JsonFormsControl('#/properties/zweck', 'Zweck'),
       ], [
         'addButtonLabel' => 'Ausgabe hinzufügen',
         'removeButtonLabel' => 'Ausgabe entfernen',
       ]),
       new JsonFormsControl('#/properties/kosten/properties/sonstigeAusgabenGesamt',
-        'Sonstige Ausgaben gesamt', NULL, NULL, $currency),
+        'Sonstige Ausgaben gesamt in ' . $currency),
     ];
 
     parent::__construct(

--- a/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1SonstigeMittelUiSchema.php
+++ b/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1SonstigeMittelUiSchema.php
@@ -31,13 +31,13 @@ final class AVK1SonstigeMittelUiSchema extends JsonFormsGroup {
       new JsonFormsArray('#/properties/finanzierung/properties/sonstigeMittel', '', NULL, [
         new JsonFormsHidden('#/properties/_identifier'),
         new JsonFormsControl('#/properties/quelle', 'Quelle'),
-        new JsonFormsControl('#/properties/betrag', 'Betrag', NULL, NULL, $currency),
+        new JsonFormsControl('#/properties/betrag', 'Betrag in ' . $currency),
       ], [
         'addButtonLabel' => 'Sonstige Mittel hinzufügen',
         'removeButtonLabel' => 'Sonstige Mittel entfernen',
       ]),
       new JsonFormsControl('#/properties/finanzierung/properties/sonstigeMittelGesamt',
-        'Sonstige Mittel gesamt', NULL, NULL, $currency),
+        'Sonstige Mittel gesamt in ' . $currency),
     ];
 
     parent::__construct(

--- a/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1UiSchema.php
+++ b/Civi/Funding/Form/SonstigeAktivitaet/UISchema/AVK1UiSchema.php
@@ -47,7 +47,7 @@ final class AVK1UiSchema extends JsonFormsGroup {
           new JsonFormsGroup('Unterkunft und Verpflegung', [
             new JsonFormsControl(
               '#/properties/kosten/properties/unterkunftUndVerpflegung',
-              'Unterkunft und Verpflegung', NULL, NULL, $currency
+              'Unterkunft und Verpflegung in ' . $currency
             ),
           ], 'Hier können Sie die Kosten für Unterbringung und Verpflegung angeben.'),
           // Abschnitt I.2
@@ -62,11 +62,13 @@ final class AVK1UiSchema extends JsonFormsGroup {
           new JsonFormsGroup('Nur bei internationalen Maßnahmen', [
             new JsonFormsControl(
               '#/properties/kosten/properties/versicherung/properties/teilnehmer',
-              'Kosten der Versicherung der Teilnehmer*innen', NULL, NULL, $currency
+              'Kosten der Versicherung der Teilnehmer*innen in ' . $currency
             ),
           ], 'Nur bei internationalen Maßnahmen'),
-          new JsonFormsControl('#/properties/kosten/properties/gesamtkosten',
-            'Gesamtkosten', NULL, NULL, $currency),
+          new JsonFormsGroup('Gesamtkosten', [
+            new JsonFormsControl('#/properties/kosten/properties/gesamtkosten',
+              'Gesamtkosten in ' . $currency),
+          ]),
         ]),
         // Abschnitt II
         new JsonFormsGroup('Finanzierung', [
@@ -74,26 +76,28 @@ final class AVK1UiSchema extends JsonFormsGroup {
           new JsonFormsGroup('Teilnehmer*innenbeiträge', [
             new JsonFormsControl(
               '#/properties/finanzierung/properties/teilnehmerbeitraege',
-              'Teilnehmer*innenbeiträge', NULL, NULL, $currency
+              'Teilnehmer*innenbeiträge in ' . $currency
             ),
           ], 'Bitte geben Sie an, wie viel durch die Teilnehmer*innenbeiträge eingenommen wird'),
           // Abschnitt II.2
           new JsonFormsGroup('Eigenmittel', [
             new JsonFormsControl(
               '#/properties/finanzierung/properties/eigenmittel',
-              'Eigenmittel', NULL, NULL, $currency
+              'Eigenmittel in ' . $currency
             ),
           ], 'Bitte geben Sie hier die Eigenmittel an, die Sie für Ihr Vorhaben aufbringen können.'),
           // Abschnitt II.3
           new AVK1OeffentlicheMittelUiSchema($currency),
           // Abschnitt II.4
           new AVK1SonstigeMittelUiSchema($currency),
-          // Gesamtmittel ohne Zuschuss
-          new JsonFormsControl('#/properties/finanzierung/properties/gesamtmittel',
-            'Gesamtmittel', NULL, NULL, $currency),
-          // Abschnitt II.5
-          new JsonFormsControl('#/properties/finanzierung/properties/beantragterZuschuss',
-            'Beantragter Zuschuss', NULL, NULL, $currency),
+          new JsonFormsGroup('Gesamtfinanzierung und beantragter Zuschuss', [
+            // Gesamtmittel ohne Zuschuss
+            new JsonFormsControl('#/properties/finanzierung/properties/gesamtmittel',
+              'Gesamtfinanzierung in ' . $currency),
+            // Abschnitt II.5
+            new JsonFormsControl('#/properties/finanzierung/properties/beantragterZuschuss',
+              'Beantragter Zuschuss in ' . $currency),
+          ]),
         ]),
       ]),
       // Beschreibung des Vorhabens (not part of default "AV-K1")
@@ -113,7 +117,7 @@ final class AVK1UiSchema extends JsonFormsGroup {
         new JsonFormsControl('#/properties/beschreibung/properties/ziele',
           'Welche Ziele hat die Veranstaltung? (Mehrfachauswahl möglich)'),
         new JsonFormsControl('#/properties/beschreibung/properties/bildungsanteil',
-          'Wie hoch ist der Bildungsanteil des Vorhabens?', NULL, NULL, '%'),
+          'Wie hoch ist der Bildungsanteil des Vorhabens in %?'),
         new JsonFormsControl('#/properties/beschreibung/properties/veranstaltungsort',
           'Wo findet die Veranstaltung statt?'),
         new JsonFormsControl('#/properties/beschreibung/properties/partner',


### PR DESCRIPTION
The suffix is placed in a new line in a Drupal Form which makes the form unnecessary large.