### PR TITLE
Use option group `file_type` instead of `funding_file_type`

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        civicrm-image-tags: [ '5-drupal', '5.57-drupal-php8.0' ]
+        civicrm-image-tags: [ '5-drupal', '5.62-drupal-php8.0' ]
     name: PHPUnit with Docker image michaelmcandrew/civicrm:${{ matrix.civicrm-image-tags }}
     env:
       CIVICRM_IMAGE_TAG: ${{ matrix.civicrm-image-tags }}

--- a/Civi/Funding/Controller/PaymentInstructionDownloadController.php
+++ b/Civi/Funding/Controller/PaymentInstructionDownloadController.php
@@ -19,7 +19,7 @@ declare(strict_types = 1);
 
 namespace Civi\Funding\Controller;
 
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\FundingAttachmentManagerInterface;
 use Civi\Funding\PayoutProcess\DrawdownManager;
 use CRM_Funding_ExtensionUtil as E;
@@ -69,7 +69,7 @@ final class PaymentInstructionDownloadController implements PageControllerInterf
     $attachment = $this->attachmentManager->getLastByFileType(
       'civicrm_funding_drawdown',
       $drawdownId,
-      FileTypeIds::PAYMENT_INSTRUCTION,
+      FileTypeNames::PAYMENT_INSTRUCTION,
     );
 
     if (NULL === $attachment) {

--- a/Civi/Funding/Controller/TransferContractDownloadController.php
+++ b/Civi/Funding/Controller/TransferContractDownloadController.php
@@ -19,7 +19,7 @@ declare(strict_types = 1);
 
 namespace Civi\Funding\Controller;
 
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\FundingAttachmentManagerInterface;
 use Civi\Funding\FundingCase\FundingCaseManager;
 use CRM_Funding_ExtensionUtil as E;
@@ -72,7 +72,7 @@ final class TransferContractDownloadController implements PageControllerInterfac
     $attachment = $this->attachmentManager->getLastByFileType(
       'civicrm_funding_case',
       $fundingCaseId,
-      FileTypeIds::TRANSFER_CONTRACT,
+      FileTypeNames::TRANSFER_CONTRACT,
     );
 
     if (NULL === $attachment) {

--- a/Civi/Funding/FundingAttachmentManagerInterface.php
+++ b/Civi/Funding/FundingAttachmentManagerInterface.php
@@ -58,7 +58,7 @@ interface FundingAttachmentManagerInterface {
   public function attachFileUniqueByFileType(
     string $entityTable,
     int $entityId,
-    int $fileTypeId,
+    string $fileTypeName,
     string $filename,
     string $mimeType,
     array $optional = []
@@ -79,12 +79,12 @@ interface FundingAttachmentManagerInterface {
    *
    * @throws \CRM_Core_Exception
    */
-  public function getByFileType(string $entityTable, int $entityId, int $fileTypeId): array;
+  public function getByFileType(string $entityTable, int $entityId, string $fileTypeName): array;
 
   /**
    * @throws \CRM_Core_Exception
    */
-  public function getLastByFileType(string $entityTable, int $entityId, int $fileTypeId): ?AttachmentEntity;
+  public function getLastByFileType(string $entityTable, int $entityId, string $fileTypeName): ?AttachmentEntity;
 
   /**
    * @return bool
@@ -92,7 +92,7 @@ interface FundingAttachmentManagerInterface {
    *
    * @throws \CRM_Core_Exception
    */
-  public function has(string $entityTable, int $entityId, int $fileTypeId): bool;
+  public function has(string $entityTable, int $entityId, string $fileTypeName): bool;
 
   /**
    * @throws \CRM_Core_Exception

--- a/Civi/Funding/FundingCase/FundingCaseManager.php
+++ b/Civi/Funding/FundingCase/FundingCaseManager.php
@@ -25,7 +25,7 @@ use Civi\Funding\Entity\FundingCaseEntity;
 use Civi\Funding\Event\FundingCase\FundingCaseCreatedEvent;
 use Civi\Funding\Event\FundingCase\FundingCaseDeletedEvent;
 use Civi\Funding\Event\FundingCase\FundingCaseUpdatedEvent;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\FundingAttachmentManagerInterface;
 use Civi\RemoteTools\Api4\Api4Interface;
 use Civi\RemoteTools\Api4\Query\CompositeCondition;
@@ -193,7 +193,7 @@ class FundingCaseManager {
    * @throws \CRM_Core_Exception
    */
   public function hasTransferContract(int $id): bool {
-    return $this->attachmentManager->has('civicrm_funding_case', $id, FileTypeIds::TRANSFER_CONTRACT);
+    return $this->attachmentManager->has('civicrm_funding_case', $id, FileTypeNames::TRANSFER_CONTRACT);
   }
 
   /**

--- a/Civi/Funding/PayoutProcess/Handler/PaymentInstructionRenderHandler.php
+++ b/Civi/Funding/PayoutProcess/Handler/PaymentInstructionRenderHandler.php
@@ -21,7 +21,7 @@ namespace Civi\Funding\PayoutProcess\Handler;
 
 use Civi\Funding\DocumentRender\DocumentRendererInterface;
 use Civi\Funding\Entity\FundingCaseTypeEntity;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\FundingAttachmentManagerInterface;
 use Civi\Funding\PayoutProcess\Command\PaymentInstructionRenderCommand;
 use Civi\Funding\PayoutProcess\Command\PaymentInstructionRenderResult;
@@ -68,7 +68,7 @@ final class PaymentInstructionRenderHandler implements PaymentInstructionRenderH
     $attachment = $this->attachmentManager->getLastByFileType(
       'civicrm_funding_case_type',
       $fundingCaseType->getId(),
-      FileTypeIds::PAYMENT_INSTRUCTION_TEMPLATE,
+      FileTypeNames::PAYMENT_INSTRUCTION_TEMPLATE,
     );
 
     if (NULL === $attachment) {

--- a/Civi/Funding/PayoutProcess/PaymentInstructionCreator.php
+++ b/Civi/Funding/PayoutProcess/PaymentInstructionCreator.php
@@ -21,7 +21,7 @@ namespace Civi\Funding\PayoutProcess;
 
 use Civi\Funding\Entity\DrawdownEntity;
 use Civi\Funding\Exception\FundingException;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\FundingAttachmentManagerInterface;
 use Civi\Funding\FundingCase\FundingCaseManager;
 use Civi\Funding\FundingProgram\FundingCaseTypeManager;
@@ -100,7 +100,7 @@ class PaymentInstructionCreator {
     $this->attachmentManager->attachFileUniqueByFileType(
       'civicrm_funding_drawdown',
       $drawdown->getId(),
-      FileTypeIds::PAYMENT_INSTRUCTION,
+      FileTypeNames::PAYMENT_INSTRUCTION,
       $result->getFilename(),
       $result->getMimeType(),
       [

--- a/Civi/Funding/TransferContract/Handler/TransferContractRenderHandler.php
+++ b/Civi/Funding/TransferContract/Handler/TransferContractRenderHandler.php
@@ -21,7 +21,7 @@ namespace Civi\Funding\TransferContract\Handler;
 
 use Civi\Funding\DocumentRender\DocumentRendererInterface;
 use Civi\Funding\Entity\FundingCaseTypeEntity;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\FundingAttachmentManagerInterface;
 use Civi\Funding\TransferContract\Command\TransferContractRenderCommand;
 use Civi\Funding\TransferContract\Command\TransferContractRenderResult;
@@ -66,7 +66,7 @@ final class TransferContractRenderHandler implements TransferContractRenderHandl
     $attachment = $this->attachmentManager->getLastByFileType(
       'civicrm_funding_case_type',
       $fundingCaseType->getId(),
-      FileTypeIds::TRANSFER_CONTRACT_TEMPLATE,
+      FileTypeNames::TRANSFER_CONTRACT_TEMPLATE,
     );
 
     if (NULL === $attachment) {

--- a/Civi/Funding/TransferContract/TransferContractCreator.php
+++ b/Civi/Funding/TransferContract/TransferContractCreator.php
@@ -23,7 +23,7 @@ use Civi\Funding\ApplicationProcess\EligibleApplicationProcessesLoader;
 use Civi\Funding\Entity\FundingCaseEntity;
 use Civi\Funding\Entity\FundingCaseTypeEntity;
 use Civi\Funding\Entity\FundingProgramEntity;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\FundingAttachmentManagerInterface;
 use Civi\Funding\TransferContract\Command\TransferContractRenderCommand;
 use Civi\Funding\TransferContract\Handler\TransferContractRenderHandlerInterface;
@@ -67,7 +67,7 @@ class TransferContractCreator {
     $this->attachmentManager->attachFileUniqueByFileType(
       'civicrm_funding_case',
       $fundingCase->getId(),
-      FileTypeIds::TRANSFER_CONTRACT,
+      FileTypeNames::TRANSFER_CONTRACT,
       $result->getFilename(),
       $result->getMimeType(),
       [

--- a/Civi/RemoteTools/Api4/OptionValueLoader.php
+++ b/Civi/RemoteTools/Api4/OptionValueLoader.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Api4;
+
+final class OptionValueLoader implements OptionValueLoaderInterface {
+
+  private Api4Interface $api4;
+
+  /**
+   * @phpstan-var array<string, array<string, string|null>>
+   */
+  private array $values = [];
+
+  public function __construct(Api4Interface $api4) {
+    $this->api4 = $api4;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getOptionValue(string $groupName, string $optionName): ?string {
+    if (array_key_exists($optionName, $this->values[$groupName] ?? [])) {
+      return $this->values[$groupName][$optionName];
+    }
+
+    $action = $this->api4->createGetAction('OptionValue')
+      ->setCheckPermissions(FALSE)
+      ->addSelect('value')
+      ->addWhere('option_group_id:name', '=', $groupName)
+      ->addWhere('name', '=', $optionName);
+    $result = $this->api4->executeAction($action);
+
+    $this->values[$groupName] ??= [];
+
+    return $this->values[$groupName][$optionName] ??= $result->first()['value'] ?? NULL;
+  }
+
+}

--- a/Civi/RemoteTools/Api4/OptionValueLoaderInterface.php
+++ b/Civi/RemoteTools/Api4/OptionValueLoaderInterface.php
@@ -17,16 +17,13 @@
 
 declare(strict_types = 1);
 
-namespace Civi\Funding;
+namespace Civi\RemoteTools\Api4;
 
-final class FileTypeIds {
+interface OptionValueLoaderInterface {
 
-  public const PAYMENT_INSTRUCTION = 63785202;
-
-  public const PAYMENT_INSTRUCTION_TEMPLATE = 63785203;
-
-  public const TRANSFER_CONTRACT = 63785200;
-
-  public const TRANSFER_CONTRACT_TEMPLATE = 63785201;
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function getOptionValue(string $groupName, string $optionName): ?string;
 
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "webmozart/assert": "^1.10"
     },
     "require-dev": {
-        "civicrm/civicrm-core": "^5.57",
+        "civicrm/civicrm-core": "^5.62",
         "psr/container": ">=1.1.0",
         "symfony/dependency-injection": ">=4.2"
     },

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>0.8.0</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.57</ver>
+    <ver>5.62</ver>
   </compatibility>
   <comments/>
   <requires>

--- a/managed/OptionValuesFileType.mgd.php
+++ b/managed/OptionValuesFileType.mgd.php
@@ -7,40 +7,15 @@ use CRM_Funding_ExtensionUtil as E;
 
 return [
   [
-    'name' => 'OptionGroup_funding_file_type',
-    'entity' => 'OptionGroup',
-    'cleanup' => 'unused',
-    'update' => 'always',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        // Might be replaced by file_type group in core. https://github.com/civicrm/civicrm-core/pull/25904
-        'name' => 'funding_file_type',
-        'title' => 'Funding File Type',
-        'description' => 'File types in the funding extension',
-        'data_type' => 'String',
-        'is_reserved' => TRUE,
-        'is_active' => TRUE,
-        'is_locked' => FALSE,
-        'option_value_fields' => [
-          'name',
-          'label',
-          'description',
-        ],
-      ],
-    ],
-  ],
-  [
-    'name' => 'OptionValue_funding_file_type.transfer_contract',
+    'name' => 'OptionValue_file_type.transfer_contract',
     'entity' => 'OptionValue',
     'cleanup' => 'unused',
     'update' => 'always',
     'params' => [
       'version' => 4,
       'values' => [
-        'option_group_id.name' => 'funding_file_type',
+        'option_group_id.name' => 'file_type',
         'label' => E::ts('Transfer Contract'),
-        'value' => FileTypeIds::TRANSFER_CONTRACT,
         'name' => FileTypeNames::TRANSFER_CONTRACT,
         'grouping' => 'funding',
         'filter' => 0,
@@ -53,16 +28,15 @@ return [
     ],
   ],
   [
-    'name' => 'OptionValue_funding_file_type.transfer_contract_template',
+    'name' => 'OptionValue_file_type.transfer_contract_template',
     'entity' => 'OptionValue',
     'cleanup' => 'unused',
     'update' => 'always',
     'params' => [
       'version' => 4,
       'values' => [
-        'option_group_id.name' => 'funding_file_type',
+        'option_group_id.name' => 'file_type',
         'label' => E::ts('Transfer Contract Template'),
-        'value' => FileTypeIds::TRANSFER_CONTRACT_TEMPLATE,
         'name' => FileTypeNames::TRANSFER_CONTRACT_TEMPLATE,
         'grouping' => 'funding',
         'filter' => 0,
@@ -75,16 +49,15 @@ return [
     ],
   ],
   [
-    'name' => 'OptionValue_funding_file_type.payment_instruction',
+    'name' => 'OptionValue_file_type.payment_instruction',
     'entity' => 'OptionValue',
     'cleanup' => 'unused',
     'update' => 'always',
     'params' => [
       'version' => 4,
       'values' => [
-        'option_group_id.name' => 'funding_file_type',
+        'option_group_id.name' => 'file_type',
         'label' => E::ts('Payment Instruction'),
-        'value' => FileTypeIds::PAYMENT_INSTRUCTION,
         'name' => FileTypeNames::PAYMENT_INSTRUCTION,
         'grouping' => 'funding',
         'filter' => 0,
@@ -97,16 +70,15 @@ return [
     ],
   ],
   [
-    'name' => 'OptionValue_funding_file_type.payment_instruction_template',
+    'name' => 'OptionValue_file_type.payment_instruction_template',
     'entity' => 'OptionValue',
     'cleanup' => 'unused',
     'update' => 'always',
     'params' => [
       'version' => 4,
       'values' => [
-        'option_group_id.name' => 'funding_file_type',
+        'option_group_id.name' => 'file_type',
         'label' => E::ts('Payment Instruction Template'),
-        'value' => FileTypeIds::PAYMENT_INSTRUCTION_TEMPLATE,
         'name' => FileTypeNames::PAYMENT_INSTRUCTION_TEMPLATE,
         'grouping' => 'funding',
         'filter' => 0,

--- a/services/remote-tools.php
+++ b/services/remote-tools.php
@@ -27,6 +27,8 @@ use Civi\RemoteTools\Api4\Api4;
 use Civi\RemoteTools\Api4\Api4Interface;
 use Civi\RemoteTools\Api4\OptionsLoader;
 use Civi\RemoteTools\Api4\OptionsLoaderInterface;
+use Civi\RemoteTools\Api4\OptionValueLoader;
+use Civi\RemoteTools\Api4\OptionValueLoaderInterface;
 use Civi\RemoteTools\Authorization\PossiblePermissionsLoader;
 use Civi\RemoteTools\Authorization\PossiblePermissionsLoaderInterface;
 use Civi\RemoteTools\Database\TransactionFactory;
@@ -46,6 +48,7 @@ $container->register(Api3Interface::class, Api3::class);
 $container->register(TransactionFactory::class);
 
 $container->autowire(OptionsLoaderInterface::class, OptionsLoader::class);
+$container->autowire(OptionValueLoaderInterface::class, OptionValueLoader::class);
 $container->autowire(PossiblePermissionsLoaderInterface::class, PossiblePermissionsLoader::class);
 
 $container->autowire(ApiAuthorizeInitRequestSubscriber::class)

--- a/tests/phpunit/Civi/Api4/FundingCaseInfoTest.php
+++ b/tests/phpunit/Civi/Api4/FundingCaseInfoTest.php
@@ -20,7 +20,7 @@ declare(strict_types = 1);
 namespace Civi\Api4;
 
 use Civi\Funding\AbstractFundingHeadlessTestCase;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\Fixtures\ApplicationProcessFixture;
 use Civi\Funding\Fixtures\AttachmentFixture;
 use Civi\Funding\Fixtures\ContactFixture;
@@ -58,7 +58,7 @@ final class FundingCaseInfoTest extends AbstractFundingHeadlessTestCase {
       'civicrm_funding_case',
       $fundingCase->getId(),
       E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx'),
-      ['file_type_id' => FileTypeIds::TRANSFER_CONTRACT],
+      ['file_type_id:name' => FileTypeNames::TRANSFER_CONTRACT],
     );
     $applicationProcess = ApplicationProcessFixture::addFixture(
       $fundingCase->getId(),

--- a/tests/phpunit/Civi/Api4/FundingCaseTest.php
+++ b/tests/phpunit/Civi/Api4/FundingCaseTest.php
@@ -27,7 +27,7 @@ use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Traits\FundingCaseTestFixturesTrait;
 use Civi\Funding\AbstractFundingHeadlessTestCase;
 use Civi\Funding\Api4\Permissions;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\Fixtures\AttachmentFixture;
 use Civi\Funding\Fixtures\FundingCaseContactRelationFixture;
 use Civi\Funding\Util\SessionTestUtil;
@@ -72,7 +72,7 @@ final class FundingCaseTest extends AbstractFundingHeadlessTestCase {
       'civicrm_funding_case_type',
       $this->fundingCaseTypeId,
       E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx'),
-      ['file_type_id' => FileTypeIds::TRANSFER_CONTRACT_TEMPLATE],
+      ['file_type_id:name' => FileTypeNames::TRANSFER_CONTRACT_TEMPLATE],
     );
 
     $result = FundingCase::approve()
@@ -118,14 +118,14 @@ final class FundingCaseTest extends AbstractFundingHeadlessTestCase {
       'civicrm_funding_case_type',
       $this->fundingCaseTypeId,
       E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx'),
-      ['file_type_id' => FileTypeIds::TRANSFER_CONTRACT_TEMPLATE],
+      ['file_type_id:name' => FileTypeNames::TRANSFER_CONTRACT_TEMPLATE],
     );
 
     $transferContractAttachment = AttachmentFixture::addFixture(
       'civicrm_funding_case',
       $this->permittedFundingCaseId,
       E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx'),
-      ['file_type_id' => FileTypeIds::TRANSFER_CONTRACT],
+      ['file_type_id:name' => FileTypeNames::TRANSFER_CONTRACT],
     );
 
     $result = FundingCase::recreateTransferContract()

--- a/tests/phpunit/Civi/Api4/FundingTransferContractTest.php
+++ b/tests/phpunit/Civi/Api4/FundingTransferContractTest.php
@@ -20,7 +20,7 @@ declare(strict_types = 1);
 namespace Civi\Api4;
 
 use Civi\Funding\AbstractFundingHeadlessTestCase;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\Fixtures\AttachmentFixture;
 use Civi\Funding\Fixtures\ContactFixture;
 use Civi\Funding\Fixtures\FundingCaseContactRelationFixture;
@@ -58,7 +58,7 @@ final class FundingTransferContractTest extends AbstractFundingHeadlessTestCase 
       'civicrm_funding_case',
       $fundingCase->getId(),
       E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx'),
-      ['file_type_id' => FileTypeIds::TRANSFER_CONTRACT],
+      ['file_type_id:name' => FileTypeNames::TRANSFER_CONTRACT],
     );
 
     $contact = ContactFixture::addIndividual();

--- a/tests/phpunit/Civi/Api4/RemoteFundingCaseInfoTest.php
+++ b/tests/phpunit/Civi/Api4/RemoteFundingCaseInfoTest.php
@@ -20,7 +20,7 @@ declare(strict_types = 1);
 namespace Civi\Api4;
 
 use Civi\Funding\AbstractRemoteFundingHeadlessTestCase;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\Fixtures\ApplicationProcessFixture;
 use Civi\Funding\Fixtures\AttachmentFixture;
 use Civi\Funding\Fixtures\ContactFixture;
@@ -56,7 +56,7 @@ final class RemoteFundingCaseInfoTest extends AbstractRemoteFundingHeadlessTestC
       'civicrm_funding_case',
       $fundingCase->getId(),
       E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx'),
-      ['file_type_id' => FileTypeIds::TRANSFER_CONTRACT],
+      ['file_type_id:name' => FileTypeNames::TRANSFER_CONTRACT],
     );
     $applicationProcess = ApplicationProcessFixture::addFixture(
       $fundingCase->getId(),

--- a/tests/phpunit/Civi/Api4/RemoteFundingTransferContractTest.php
+++ b/tests/phpunit/Civi/Api4/RemoteFundingTransferContractTest.php
@@ -20,7 +20,7 @@ declare(strict_types = 1);
 namespace Civi\Api4;
 
 use Civi\Funding\AbstractRemoteFundingHeadlessTestCase;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\Fixtures\AttachmentFixture;
 use Civi\Funding\Fixtures\ContactFixture;
 use Civi\Funding\Fixtures\FundingCaseContactRelationFixture;
@@ -55,7 +55,7 @@ final class RemoteFundingTransferContractTest extends AbstractRemoteFundingHeadl
       'civicrm_funding_case',
       $fundingCase->getId(),
       E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx'),
-      ['file_type_id' => FileTypeIds::TRANSFER_CONTRACT],
+      ['file_type_id:name' => FileTypeNames::TRANSFER_CONTRACT],
     );
 
     $contact = ContactFixture::addIndividual();

--- a/tests/phpunit/Civi/Funding/Fixtures/AttachmentFixture.php
+++ b/tests/phpunit/Civi/Funding/Fixtures/AttachmentFixture.php
@@ -40,7 +40,6 @@ final class AttachmentFixture {
       'entity_id' => $entityId,
       'name' => basename($filename),
       'mime_type' => mime_content_type($filename),
-      'file_type_id' => NULL,
       'content' => file_get_contents($filename),
       'sequential' => 1,
       // Ensure path is returned.
@@ -64,6 +63,13 @@ final class AttachmentFixture {
       File::update()
         ->setCheckPermissions(FALSE)
         ->addValue('file_type_id', $values['file_type_id'])
+        ->addWhere('id', '=', $attachment->getId())
+        ->execute();
+    }
+    if (isset($values['file_type_id:name'])) {
+      File::update()
+        ->setCheckPermissions(FALSE)
+        ->addValue('file_type_id:name', $values['file_type_id:name'])
         ->addWhere('id', '=', $attachment->getId())
         ->execute();
     }

--- a/tests/phpunit/Civi/Funding/FundingCase/FundingCaseManagerTest.php
+++ b/tests/phpunit/Civi/Funding/FundingCase/FundingCaseManagerTest.php
@@ -29,7 +29,7 @@ use Civi\Funding\Entity\FundingCaseEntity;
 use Civi\Funding\EntityFactory\FundingCaseFactory;
 use Civi\Funding\Event\FundingCase\FundingCaseCreatedEvent;
 use Civi\Funding\Event\FundingCase\FundingCaseUpdatedEvent;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\Fixtures\ContactFixture;
 use Civi\Funding\Fixtures\FundingCaseContactRelationFixture;
 use Civi\Funding\Fixtures\FundingCaseFixture;
@@ -289,7 +289,7 @@ final class FundingCaseManagerTest extends AbstractFundingHeadlessTestCase {
 
   public function testHasTransferContract(): void {
     $this->attachmentManagerMock->expects(static::once())->method('has')
-      ->with('civicrm_funding_case', 12, FileTypeIds::TRANSFER_CONTRACT)
+      ->with('civicrm_funding_case', 12, FileTypeNames::TRANSFER_CONTRACT)
       ->willReturn(TRUE);
 
     static::assertTrue($this->fundingCaseManager->hasTransferContract(12));

--- a/tests/phpunit/Civi/Funding/PayoutProcess/Handler/PaymentInstructionRenderHandlerTest.php
+++ b/tests/phpunit/Civi/Funding/PayoutProcess/Handler/PaymentInstructionRenderHandlerTest.php
@@ -26,7 +26,7 @@ use Civi\Funding\EntityFactory\FundingCaseFactory;
 use Civi\Funding\EntityFactory\FundingCaseTypeFactory;
 use Civi\Funding\EntityFactory\FundingProgramFactory;
 use Civi\Funding\EntityFactory\PayoutProcessFactory;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\FundingAttachmentManagerInterface;
 use Civi\Funding\PayoutProcess\BankAccount;
 use Civi\Funding\PayoutProcess\Command\PaymentInstructionRenderCommand;
@@ -68,8 +68,11 @@ final class PaymentInstructionRenderHandlerTest extends TestCase {
       'entity_id' => FundingCaseTypeFactory::DEFAULT_ID,
     ]);
     $this->attachmentManagerMock->method('getLastByFileType')
-      ->with('civicrm_funding_case_type', FundingCaseTypeFactory::DEFAULT_ID, FileTypeIds::PAYMENT_INSTRUCTION_TEMPLATE)
-      ->willReturn($paymentInstructionAttachment);
+      ->with(
+        'civicrm_funding_case_type',
+        FundingCaseTypeFactory::DEFAULT_ID,
+        FileTypeNames::PAYMENT_INSTRUCTION_TEMPLATE
+      )->willReturn($paymentInstructionAttachment);
 
     $this->documentRendererMock->expects(static::once())->method('render')
       ->with(
@@ -91,8 +94,11 @@ final class PaymentInstructionRenderHandlerTest extends TestCase {
   public function testHandleNoTemplate(): void {
     $command = $this->createCommand();
     $this->attachmentManagerMock->method('getLastByFileType')
-      ->with('civicrm_funding_case_type', FundingCaseTypeFactory::DEFAULT_ID, FileTypeIds::PAYMENT_INSTRUCTION_TEMPLATE)
-      ->willReturn(NULL);
+      ->with(
+        'civicrm_funding_case_type',
+        FundingCaseTypeFactory::DEFAULT_ID,
+        FileTypeNames::PAYMENT_INSTRUCTION_TEMPLATE
+      )->willReturn(NULL);
 
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage(sprintf(

--- a/tests/phpunit/Civi/Funding/TestAttachmentManager.php
+++ b/tests/phpunit/Civi/Funding/TestAttachmentManager.php
@@ -56,7 +56,7 @@ final class TestAttachmentManager implements FundingAttachmentManagerInterface {
   public function attachFileUniqueByFileType(
     string $entityTable,
     int $entityId,
-    int $fileTypeId,
+    string $fileTypeName,
     string $filename,
     string $mimeType,
     array $optional = []
@@ -64,7 +64,7 @@ final class TestAttachmentManager implements FundingAttachmentManagerInterface {
     return $this->attachmentManager->attachFileUniqueByFileType(
       $entityTable,
       $entityId,
-      $fileTypeId,
+      $fileTypeName,
       $filename,
       $mimeType,
       $optional,
@@ -88,22 +88,22 @@ final class TestAttachmentManager implements FundingAttachmentManagerInterface {
   /**
    * @inheritDoc
    */
-  public function getByFileType(string $entityTable, int $entityId, int $fileTypeId): array {
-    return $this->attachmentManager->getByFileType($entityTable, $entityId, $fileTypeId);
+  public function getByFileType(string $entityTable, int $entityId, string $fileTypeName): array {
+    return $this->attachmentManager->getByFileType($entityTable, $entityId, $fileTypeName);
   }
 
   /**
    * @inheritDoc
    */
-  public function getLastByFileType(string $entityTable, int $entityId, int $fileTypeId): ?AttachmentEntity {
-    return $this->attachmentManager->getLastByFileType($entityTable, $entityId, $fileTypeId);
+  public function getLastByFileType(string $entityTable, int $entityId, string $fileTypeName): ?AttachmentEntity {
+    return $this->attachmentManager->getLastByFileType($entityTable, $entityId, $fileTypeName);
   }
 
   /**
    * @inheritDoc
    */
-  public function has(string $entityTable, int $entityId, int $fileTypeId): bool {
-    return $this->attachmentManager->has($entityTable, $entityId, $fileTypeId);
+  public function has(string $entityTable, int $entityId, string $fileTypeName): bool {
+    return $this->attachmentManager->has($entityTable, $entityId, $fileTypeName);
   }
 
   /**

--- a/tests/phpunit/Civi/Funding/TransferContract/Handler/TransferContractRenderHandlerTest.php
+++ b/tests/phpunit/Civi/Funding/TransferContract/Handler/TransferContractRenderHandlerTest.php
@@ -24,7 +24,7 @@ use Civi\Funding\EntityFactory\ApplicationProcessBundleFactory;
 use Civi\Funding\EntityFactory\AttachmentFactory;
 use Civi\Funding\EntityFactory\FundingCaseFactory;
 use Civi\Funding\EntityFactory\FundingCaseTypeFactory;
-use Civi\Funding\FileTypeIds;
+use Civi\Funding\FileTypeNames;
 use Civi\Funding\FundingAttachmentManagerInterface;
 use Civi\Funding\TransferContract\Command\TransferContractRenderCommand;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -68,7 +68,7 @@ final class TransferContractRenderHandlerTest extends TestCase {
       'entity_id' => FundingCaseTypeFactory::DEFAULT_ID,
     ]);
     $this->attachmentManagerMock->method('getLastByFileType')
-      ->with('civicrm_funding_case_type', FundingCaseTypeFactory::DEFAULT_ID, FileTypeIds::TRANSFER_CONTRACT_TEMPLATE)
+      ->with('civicrm_funding_case_type', FundingCaseTypeFactory::DEFAULT_ID, FileTypeNames::TRANSFER_CONTRACT_TEMPLATE)
       ->willReturn($transferContractAttachment);
 
     $this->documentRendererMock->expects(static::once())->method('render')
@@ -89,7 +89,7 @@ final class TransferContractRenderHandlerTest extends TestCase {
   public function testHandleNoTemplate(): void {
     $command = $this->createCommand();
     $this->attachmentManagerMock->method('getLastByFileType')
-      ->with('civicrm_funding_case_type', FundingCaseTypeFactory::DEFAULT_ID, FileTypeIds::TRANSFER_CONTRACT_TEMPLATE)
+      ->with('civicrm_funding_case_type', FundingCaseTypeFactory::DEFAULT_ID, FileTypeNames::TRANSFER_CONTRACT_TEMPLATE)
       ->willReturn(NULL);
 
     $this->expectException(\RuntimeException::class);

--- a/tests/phpunit/Civi/RemoteTools/Api4/OptionValueLoaderTest.php
+++ b/tests/phpunit/Civi/RemoteTools/Api4/OptionValueLoaderTest.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Api4;
+
+use Civi\Api4\Generic\DAOGetAction;
+use Civi\Api4\Generic\Result;
+use Civi\Funding\Traits\CreateMockTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\RemoteTools\Api4\OptionValueLoader
+ */
+final class OptionValueLoaderTest extends TestCase {
+
+  use CreateMockTrait;
+
+  /**
+   * @var \Civi\RemoteTools\Api4\Api4Interface&\PHPUnit\Framework\MockObject\MockObject
+   */
+  private MockObject $api4Mock;
+
+  private OptionValueLoader $optionValueLoader;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->api4Mock = $this->createMock(Api4Interface::class);
+    $this->optionValueLoader = new OptionValueLoader($this->api4Mock);
+  }
+
+  public function testGetOptionValue(): void {
+    $action = $this->createApi4ActionMock(DAOGetAction::class, 'OptionValue', 'get');
+    $this->api4Mock->method('createGetAction')
+      ->with('OptionValue')
+      ->willReturn($action);
+
+    $this->api4Mock->expects(static::once())->method('executeAction')
+      ->with($action)
+      ->willReturnCallback(
+        function (DAOGetAction $action) {
+          static::assertFalse($action->getCheckPermissions());
+          static::assertSame([
+            ['option_group_id:name', '=', 'group', FALSE],
+            ['name', '=', 'optionName', FALSE],
+          ], $action->getWhere());
+
+          return new Result([['value' => 'optionValue']]);
+        }
+      );
+
+    static::assertSame('optionValue', $this->optionValueLoader->getOptionValue('group', 'optionName'));
+    // Test that value is cached.
+    static::assertSame('optionValue', $this->optionValueLoader->getOptionValue('group', 'optionName'));
+  }
+
+}


### PR DESCRIPTION
The option group for field `file_type_id` of entity `File` is available since CiviCRM 5.62.