### PR TITLE
Add "save&copy" as possible action in new "SammelantragKurs" applications

### DIFF
--- a/Civi/Funding/Api4/Action/Remote/ApplicationProcess/GetAddFormAction.php
+++ b/Civi/Funding/Api4/Action/Remote/ApplicationProcess/GetAddFormAction.php
@@ -28,6 +28,10 @@ use Civi\RemoteTools\Api4\Action\Traits\ActionHandlerRunTrait;
 use Civi\RemoteTools\Api4\Action\Traits\RemoteContactIdParameterTrait;
 use Civi\RemoteTools\Api4\Action\Traits\ResolvedContactIdTrait;
 
+/**
+ * @method int getCopyDataFromId()
+ * @method $this setCopyDataFromId(int $copyDataFromId)
+ */
 final class GetAddFormAction extends AbstractAction implements RemoteActionInterface {
 
   use ActionHandlerRunTrait;
@@ -37,6 +41,11 @@ final class GetAddFormAction extends AbstractAction implements RemoteActionInter
   use RemoteContactIdParameterTrait;
 
   use ResolvedContactIdTrait;
+
+  /**
+   * @var int ID of the application process to copy the initial data from.
+   */
+  protected ?int $copyDataFromId = NULL;
 
   public function __construct(ActionHandlerInterface $actionHandler = NULL) {
     parent::__construct(RemoteFundingApplicationProcess::_getEntityName(), 'getAddForm');

--- a/Civi/Funding/ApplicationProcess/Command/ApplicationFormDataGetCommand.php
+++ b/Civi/Funding/ApplicationProcess/Command/ApplicationFormDataGetCommand.php
@@ -27,9 +27,16 @@ final class ApplicationFormDataGetCommand {
   use ApplicationProcessEntityBundleTrait;
 
   /**
+   * Data is going to be used as initial data for a new application.
+   */
+  public const FLAG_COPY = 1;
+
+  /**
    * @phpstan-var array<int, \Civi\Funding\Entity\FullApplicationProcessStatus>
    */
   private array $applicationProcessStatusList;
+
+  private int $flags;
 
   /**
    * @phpstan-param array<int, \Civi\Funding\Entity\FullApplicationProcessStatus> $applicationProcessStatusList
@@ -37,10 +44,12 @@ final class ApplicationFormDataGetCommand {
    */
   public function __construct(
     ApplicationProcessEntityBundle $applicationProcessBundle,
-    array $applicationProcessStatusList
+    array $applicationProcessStatusList,
+    int $flags = 0
   ) {
     $this->applicationProcessBundle = $applicationProcessBundle;
     $this->applicationProcessStatusList = $applicationProcessStatusList;
+    $this->flags = $flags;
   }
 
   /**
@@ -49,6 +58,10 @@ final class ApplicationFormDataGetCommand {
    */
   public function getApplicationProcessStatusList(): array {
     return $this->applicationProcessStatusList;
+  }
+
+  public function hasFlag(int $flag): bool {
+    return 0 !== ($this->flags & $flag);
   }
 
 }

--- a/Civi/Funding/ApplicationProcess/Handler/ApplicationFormDataGetHandler.php
+++ b/Civi/Funding/ApplicationProcess/Handler/ApplicationFormDataGetHandler.php
@@ -41,10 +41,18 @@ final class ApplicationFormDataGetHandler implements ApplicationFormDataGetHandl
    * @inheritDoc
    */
   public function handle(ApplicationFormDataGetCommand $command): array {
-    $data = $this->formDataFactory->createFormData(
-      $command->getApplicationProcess(),
-      $command->getFundingCase(),
-    );
+    if ($command->hasFlag(ApplicationFormDataGetCommand::FLAG_COPY)) {
+      $data = $this->formDataFactory->createFormDataForCopy(
+        $command->getApplicationProcess(),
+        $command->getFundingCase(),
+      );
+    }
+    else {
+      $data = $this->formDataFactory->createFormData(
+        $command->getApplicationProcess(),
+        $command->getFundingCase(),
+      );
+    }
 
     // Perform calculations
     $result = $this->validateHandler->handle(new ApplicationFormValidateCommand(

--- a/Civi/Funding/ApplicationProcess/Remote/Api4/ActionHandler/GetAddFormActionHandler.php
+++ b/Civi/Funding/ApplicationProcess/Remote/Api4/ActionHandler/GetAddFormActionHandler.php
@@ -20,8 +20,11 @@ declare(strict_types = 1);
 namespace Civi\Funding\ApplicationProcess\Remote\Api4\ActionHandler;
 
 use Civi\Funding\Api4\Action\Remote\ApplicationProcess\GetAddFormAction;
+use Civi\Funding\ApplicationProcess\ApplicationProcessBundleLoader;
 use Civi\Funding\ApplicationProcess\Command\ApplicationFormAddCreateCommand;
+use Civi\Funding\ApplicationProcess\Command\ApplicationFormDataGetCommand;
 use Civi\Funding\ApplicationProcess\Handler\ApplicationFormAddCreateHandlerInterface;
+use Civi\Funding\ApplicationProcess\Handler\ApplicationFormDataGetHandlerInterface;
 use Civi\Funding\FundingCase\FundingCaseManager;
 use Civi\Funding\FundingProgram\FundingCaseTypeManager;
 use Civi\Funding\FundingProgram\FundingProgramManager;
@@ -32,7 +35,11 @@ final class GetAddFormActionHandler implements ActionHandlerInterface {
 
   public const ENTITY_NAME = 'RemoteFundingApplicationProcess';
 
+  private ApplicationProcessBundleLoader $applicationProcessBundleLoader;
+
   private ApplicationFormAddCreateHandlerInterface $createHandler;
+
+  private ApplicationFormDataGetHandlerInterface $formDataGetHandler;
 
   private FundingCaseManager $fundingCaseManager;
 
@@ -41,12 +48,16 @@ final class GetAddFormActionHandler implements ActionHandlerInterface {
   private FundingProgramManager $fundingProgramManager;
 
   public function __construct(
+    ApplicationProcessBundleLoader $applicationProcessBundleLoader,
     ApplicationFormAddCreateHandlerInterface $createHandler,
+    ApplicationFormDataGetHandlerInterface $formDataGetHandler,
     FundingCaseManager $fundingCaseManager,
     FundingCaseTypeManager $fundingCaseTypeManager,
     FundingProgramManager $fundingProgramManager
   ) {
+    $this->applicationProcessBundleLoader = $applicationProcessBundleLoader;
     $this->createHandler = $createHandler;
+    $this->formDataGetHandler = $formDataGetHandler;
     $this->fundingCaseManager = $fundingCaseManager;
     $this->fundingCaseTypeManager = $fundingCaseTypeManager;
     $this->fundingProgramManager = $fundingProgramManager;
@@ -77,10 +88,28 @@ final class GetAddFormActionHandler implements ActionHandlerInterface {
       $fundingCase,
     ));
 
+    if (NULL !== $action->getCopyDataFromId()) {
+      $applicationProcessBundle = $this->applicationProcessBundleLoader->get($action->getCopyDataFromId());
+      Assert::notNull(
+        $applicationProcessBundle,
+        sprintf('Application process with ID %d not found', $action->getCopyDataFromId())
+      );
+      Assert::same(
+        $fundingCaseType->getId(),
+        $applicationProcessBundle->getFundingCaseType()->getId(),
+        'Copies are only allowed with the same funding case type'
+      );
+      $formData = $this->formDataGetHandler->handle(new ApplicationFormDataGetCommand(
+        $applicationProcessBundle,
+        $this->applicationProcessBundleLoader->getStatusList($applicationProcessBundle),
+        ApplicationFormDataGetCommand::FLAG_COPY
+      )) + $form->getData();
+    }
+
     return [
       'jsonSchema' => $form->getJsonSchema()->toArray(),
       'uiSchema' => $form->getUiSchema()->toArray(),
-      'data' => $form->getData(),
+      'data' => $formData ?? $form->getData(),
     ];
   }
 

--- a/Civi/Funding/ApplicationProcess/StatusDeterminer/AbstractApplicationProcessStatusDeterminer.php
+++ b/Civi/Funding/ApplicationProcess/StatusDeterminer/AbstractApplicationProcessStatusDeterminer.php
@@ -40,8 +40,8 @@ abstract class AbstractApplicationProcessStatusDeterminer implements Application
 
   public function getInitialStatus(string $action): string {
     $status = $this->statusActionStatusMap[NULL][$action] ?? NULL;
-    if (NULL === $status && str_ends_with($action, '&new')) {
-      $status = $this->statusActionStatusMap[NULL][substr($action, 0, -4)] ?? NULL;
+    if (NULL === $status && (str_ends_with($action, '&new') || str_ends_with($action, '&copy'))) {
+      $status = $this->statusActionStatusMap[NULL][explode('&', $action)[0]] ?? NULL;
     }
 
     if (NULL === $status) {

--- a/Civi/Funding/Form/ApplicationFormDataFactoryInterface.php
+++ b/Civi/Funding/Form/ApplicationFormDataFactoryInterface.php
@@ -36,4 +36,13 @@ interface ApplicationFormDataFactoryInterface {
    */
   public function createFormData(ApplicationProcessEntity $applicationProcess, FundingCaseEntity $fundingCase): array;
 
+  /**
+   * @phpstan-return array<string, mixed> JSON serializable.
+   *   Form data to use when creating an application as copy of an existing one.
+   */
+  public function createFormDataForCopy(
+    ApplicationProcessEntity $applicationProcess,
+    FundingCaseEntity $fundingCase
+  ): array;
+
 }

--- a/Civi/Funding/Form/SonstigeAktivitaet/AVK1FormDataFactory.php
+++ b/Civi/Funding/Form/SonstigeAktivitaet/AVK1FormDataFactory.php
@@ -49,6 +49,8 @@ final class AVK1FormDataFactory implements ApplicationFormDataFactoryInterface {
 
   /**
    * @inheritDoc
+   *
+   * @throws \CRM_Core_Exception
    */
   public function createFormData(ApplicationProcessEntity $applicationProcess, FundingCaseEntity $fundingCase): array {
     $data = [];
@@ -63,6 +65,18 @@ final class AVK1FormDataFactory implements ApplicationFormDataFactoryInterface {
     $data['projektunterlagen'] = $this->avk1ProjektunterlagenFactory->createProjektunterlagen($applicationProcess);
 
     return $data;
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function createFormDataForCopy(
+    ApplicationProcessEntity $applicationProcess,
+    FundingCaseEntity $fundingCase
+  ): array {
+    return $this->createFormData($applicationProcess, $fundingCase);
   }
 
 }

--- a/Civi/Funding/SammelantragKurs/Application/Actions/KursApplicationActionsDeterminer.php
+++ b/Civi/Funding/SammelantragKurs/Application/Actions/KursApplicationActionsDeterminer.php
@@ -32,7 +32,7 @@ final class KursApplicationActionsDeterminer extends ApplicationProcessActionsDe
 
   private const STATUS_PERMISSION_ACTIONS_MAP = [
     NULL => [
-      'application_create' => ['save', 'save&new'],
+      'application_create' => ['save', 'save&new', 'save&copy'],
     ],
     'new' => [
       'application_modify' => ['save'],

--- a/Civi/Funding/SammelantragKurs/Application/Actions/KursApplicationSubmitActionsContainer.php
+++ b/Civi/Funding/SammelantragKurs/Application/Actions/KursApplicationSubmitActionsContainer.php
@@ -32,6 +32,7 @@ final class KursApplicationSubmitActionsContainer extends AbstractApplicationSub
   public function __construct() {
     $this
       ->add('save&new', 'Speichern und neu')
+      ->add('save&copy', 'Speichern und kopieren')
       ->add('save', 'Speichern')
       ->add('modify', 'Bearbeiten')
       ->add('withdraw', 'Zurückziehen', 'Möchten Sie diesen Kurs wirklich zurückziehen?')

--- a/Civi/Funding/SammelantragKurs/Application/Data/KursApplicationFormDataFactory.php
+++ b/Civi/Funding/SammelantragKurs/Application/Data/KursApplicationFormDataFactory.php
@@ -64,4 +64,16 @@ final class KursApplicationFormDataFactory implements ApplicationFormDataFactory
     return $data;
   }
 
+  /**
+   * @inheritDoc
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function createFormDataForCopy(
+    ApplicationProcessEntity $applicationProcess,
+    FundingCaseEntity $fundingCase
+  ): array {
+    return $this->createFormData($applicationProcess, $fundingCase);
+  }
+
 }

--- a/tests/phpunit/Civi/Funding/Api4/Action/Remote/ApplicationProcess/GetAddFormActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/Remote/ApplicationProcess/GetAddFormActionTest.php
@@ -20,6 +20,7 @@ declare(strict_types = 1);
 namespace Civi\Funding\Api4\Action\Remote\ApplicationProcess;
 
 use Civi\Api4\RemoteFundingApplicationProcess;
+use Civi\Funding\Fixtures\ApplicationProcessFixture;
 use Civi\PHPUnit\Traits\ArrayAssertTrait;
 
 /**
@@ -45,6 +46,22 @@ final class GetAddFormActionTest extends AbstractAddFormActionTestCase {
     static::assertIsArray($result['jsonSchema']);
     static::assertIsArray($result['uiSchema']);
     static::assertSame([], $result['data']);
+  }
+
+  public function testCopy(): void {
+    $this->initFixtures();
+    $applicationProcess = ApplicationProcessFixture::addFixtureForTestFundingCaseType($this->fundingCase->getId());
+
+    $action = RemoteFundingApplicationProcess::getAddForm()
+      ->setRemoteContactId($this->remoteContactId)
+      ->setFundingCaseId($this->fundingCase->getId())
+      ->setCopyDataFromId($applicationProcess->getId());
+
+    $result = $action->execute();
+    static::assertArrayHasSameKeys(['jsonSchema', 'uiSchema', 'data'], $result->getArrayCopy());
+    static::assertIsArray($result['jsonSchema']);
+    static::assertIsArray($result['uiSchema']);
+    static::assertSame($applicationProcess->getTitle(), $result['data']['title']);
   }
 
   public function testInvalidFundingCaseId(): void {

--- a/tests/phpunit/Civi/Funding/ApplicationProcess/StatusDeterminer/DefaultApplicationProcessStatusDeterminerTest.php
+++ b/tests/phpunit/Civi/Funding/ApplicationProcess/StatusDeterminer/DefaultApplicationProcessStatusDeterminerTest.php
@@ -48,6 +48,7 @@ final class DefaultApplicationProcessStatusDeterminerTest extends TestCase {
   public function provideInitialActions(): iterable {
     yield ['save', 'new'];
     yield ['save&new', 'new'];
+    yield ['save&copy', 'new'];
     yield ['apply', 'applied'];
   }
 

--- a/tests/phpunit/Civi/Funding/Fixtures/ApplicationProcessFixture.php
+++ b/tests/phpunit/Civi/Funding/Fixtures/ApplicationProcessFixture.php
@@ -77,4 +77,33 @@ final class ApplicationProcessFixture {
     return ApplicationProcessEntity::fromArray($applicationProcessValues)->reformatDates();
   }
 
+  /**
+   * @phpstan-param array<string, mixed> $values
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function addFixtureForTestFundingCaseType(
+    int $fundingCaseId,
+    array $values = []
+  ): ApplicationProcessEntity {
+    $values += [
+      'start_date' => '2023-04-05',
+      'end_date' => '2023-04-06',
+      'request_data' => ['resources' => 123.45],
+    ];
+
+    $applicationProcess = self::addFixture($fundingCaseId, $values);
+
+    $externalFile = ExternalFileFixture::addFixture([
+      'identifier' => 'FundingApplicationProcess.' . $applicationProcess->getId() . ':file',
+    ]);
+    EntityFileFixture::addFixture(
+      'civicrm_funding_application_process',
+      $applicationProcess->getId(),
+      $externalFile->getFileId(),
+    );
+
+    return $applicationProcess;
+  }
+
 }

--- a/tests/phpunit/Civi/Funding/Mock/Form/FundingCaseType/TestFormDataFactory.php
+++ b/tests/phpunit/Civi/Funding/Mock/Form/FundingCaseType/TestFormDataFactory.php
@@ -60,4 +60,14 @@ final class TestFormDataFactory implements ApplicationFormDataFactoryInterface {
     return $data;
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function createFormDataForCopy(
+    ApplicationProcessEntity $applicationProcess,
+    FundingCaseEntity $fundingCase
+  ): array {
+    return $this->createFormData($applicationProcess, $fundingCase);
+  }
+
 }


### PR DESCRIPTION
With the action "save&copy" a new application will be added to a funding case and the client should show a form to add an additional application with the values of the currently saved one.

systopia-reference: 22498