### PR TITLE
Fix determination of `approve` action for funding cases

### DIFF
--- a/Civi/Funding/FundingCase/Actions/DefaultFundingCaseActionsDeterminer.php
+++ b/Civi/Funding/FundingCase/Actions/DefaultFundingCaseActionsDeterminer.php
@@ -67,16 +67,13 @@ final class DefaultFundingCaseActionsDeterminer extends FundingCaseActionsDeterm
   private function isApprovePossible(array $applicationProcessStatusList): bool {
     $eligibleCount = 0;
     foreach ($applicationProcessStatusList as $applicationProcessStatus) {
-      switch ($this->statusInfo->isEligibleStatus($applicationProcessStatus->getStatus())) {
-        case NULL:
-          return FALSE;
+      $eligible = $this->statusInfo->isEligibleStatus($applicationProcessStatus->getStatus());
+      if (NULL === $eligible) {
+        return FALSE;
+      }
 
-        case TRUE:
-          ++$eligibleCount;
-          break;
-
-        case FALSE:
-          // fall through
+      if ($eligible) {
+        ++$eligibleCount;
       }
     }
 

--- a/tests/phpunit/Civi/Funding/FundingCase/DefaultFundingCaseActionsDeterminerTest.php
+++ b/tests/phpunit/Civi/Funding/FundingCase/DefaultFundingCaseActionsDeterminerTest.php
@@ -59,7 +59,17 @@ final class DefaultFundingCaseActionsDeterminerTest extends TestCase {
     $this->statusList = [22 => new FullApplicationProcessStatus('eligible', TRUE, TRUE)];
 
     $statusInfoMock->method('isEligibleStatus')
-      ->willReturnCallback(fn (string $status) => 'eligible' === $status);
+      ->willReturnCallback(function (string $status): ?bool {
+        if ('eligible' === $status) {
+          return TRUE;
+        }
+
+        if ('withdrawn' === $status) {
+          return FALSE;
+        }
+
+        return NULL;
+      });
   }
 
   public function testGetActions(): void {
@@ -153,6 +163,16 @@ final class DefaultFundingCaseActionsDeterminerTest extends TestCase {
       'approve',
       'open',
       [],
+      ['review_calculative']
+    ));
+
+    static::assertTrue($this->actionsDeterminer->isActionAllowed(
+      'approve',
+      'open',
+      [
+        22 => new FullApplicationProcessStatus('eligible', TRUE, TRUE),
+        23 => new FullApplicationProcessStatus('withdrawn', TRUE, TRUE),
+      ],
       ['review_calculative']
     ));
   }


### PR DESCRIPTION
Because PHP uses loose comparison for `switch` funding case approval was not possible if there was one application process in a final ineligible status.