### PR TITLE
Rename _EntityFile to X_EntityFile

### DIFF
--- a/Civi/Api4/X_EntityFile.php
+++ b/Civi/Api4/X_EntityFile.php
@@ -21,18 +21,18 @@ namespace Civi\Api4;
 
 // phpcs:disable PSR1.Files.SideEffects
 if (class_exists('Civi\Api4\EntityFile')) {
-  class_alias('Civi\Api4\EntityFile', 'Civi\Api4\_EntityFile');
+  class_alias('Civi\Api4\EntityFile', 'Civi\Api4\X_EntityFile');
 }
 else {
   /**
-   * In core there's no EntityFile entity, yet. So this class is used as
-   * replacement.
+   * This class is used as replacement for EntityFile which is only available in
+   * CiviCRM >=5.67.
+   *
+   * @todo Remove when minimal supported CiviCRM version is at least 5.67.
    *
    * @searchable bridge
-   *
-   * @see https://github.com/civicrm/civicrm-core/pull/25845
    */
-  final class _EntityFile extends Generic\DAOEntity {
+  final class X_EntityFile extends Generic\DAOEntity {
 
     use Generic\Traits\EntityBridge;
 

--- a/Civi/Funding/FundingExternalFileManager.php
+++ b/Civi/Funding/FundingExternalFileManager.php
@@ -19,7 +19,7 @@ declare(strict_types = 1);
 
 namespace Civi\Funding;
 
-use Civi\Api4\_EntityFile;
+use Civi\Api4\X_EntityFile;
 use Civi\Api4\ExternalFile;
 use Civi\Funding\Entity\ExternalFileEntity;
 use Civi\RemoteTools\Api4\Api4Interface;
@@ -111,7 +111,7 @@ final class FundingExternalFileManager implements FundingExternalFileManagerInte
    * @inheritDoc
    */
   public function detachFile(ExternalFileEntity $externalFile, string $entityTable, int $entityId): void {
-    $entityFileAction = _EntityFile::delete(FALSE)
+    $entityFileAction = X_EntityFile::delete(FALSE)
       ->addWhere('file_id', '=', $externalFile->getFileId())
       ->addWhere('entity_table', '=', $entityTable)
       ->addWhere('entity_id', '=', $entityId);
@@ -131,7 +131,7 @@ final class FundingExternalFileManager implements FundingExternalFileManagerInte
       return NULL;
     }
 
-    $countAction = _EntityFile::get(FALSE)
+    $countAction = X_EntityFile::get(FALSE)
       ->selectRowCount()
       ->addWhere('file_id', '=', $externalFile->getFileId())
       ->addWhere('entity_table', '=', $entityTable)
@@ -171,7 +171,7 @@ final class FundingExternalFileManager implements FundingExternalFileManagerInte
    * @inheritDoc
    */
   public function isAttachedToTable(ExternalFileEntity $externalFile, string $table): bool {
-    $action = _EntityFile::get(FALSE)
+    $action = X_EntityFile::get(FALSE)
       ->selectRowCount()
       ->addWhere('file_id', '=', $externalFile->getFileId())
       ->addWhere('entity_table', '=', $table);
@@ -220,14 +220,14 @@ final class FundingExternalFileManager implements FundingExternalFileManagerInte
    * @throws \CRM_Core_Exception
    */
   private function attachCiviFile(int $fileId, string $entityTable, int $entityId): void {
-    $countAction = _EntityFile::get(FALSE)
+    $countAction = X_EntityFile::get(FALSE)
       ->selectRowCount()
       ->addWhere('file_id', '=', $fileId)
       ->addWhere('entity_table', '=', $entityTable)
       ->addWhere('entity_id', '=', $entityId);
 
     if (0 === $this->api4->executeAction($countAction)->count()) {
-      $entityFileAction = _EntityFile::create(FALSE)
+      $entityFileAction = X_EntityFile::create(FALSE)
         ->setValues([
           'file_id' => $fileId,
           'entity_table' => $entityTable,
@@ -243,7 +243,7 @@ final class FundingExternalFileManager implements FundingExternalFileManagerInte
    * @throws \CRM_Core_Exception
    */
   private function getFileIdsByEntity(string $entityTable, int $entityId): array {
-    $entityFileAction = _EntityFile::get(FALSE)
+    $entityFileAction = X_EntityFile::get(FALSE)
       ->addSelect('file_id')
       ->addWhere('entity_table', '=', $entityTable)
       ->addWhere('entity_id', '=', $entityId);

--- a/tests/docker-prepare.sh
+++ b/tests/docker-prepare.sh
@@ -12,6 +12,7 @@ IDENTITYTRACKER_BRANCH=master
 REMOTETOOLS_BRANCH=remote-tools-api4
 
 FUNDING_EXT_DIR=$(dirname "$(dirname "$(realpath "$0")")")
+EXT_DIR=$(dirname "$FUNDING_EXT_DIR")
 
 if ! type git >/dev/null 2>&1; then
   apt -y update
@@ -71,6 +72,7 @@ else
   cv ext:download "de.systopia.identitytracker@https://github.com/systopia/de.systopia.identitytracker/archive/refs/heads/$IDENTITYTRACKER_BRANCH.zip"
   #cv ext:download "de.systopia.remotetools@https://github.com/systopia/de.systopia.remotetools/archive/refs/tags/$REMOTETOOLS_VERSION.zip"
   cv ext:download "de.systopia.remotetools@https://github.com/systopia/de.systopia.remotetools/archive/refs/heads/$REMOTETOOLS_BRANCH.zip"
+  composer --working-dir="$EXT_DIR/de.systopia.remotetools" update --no-dev --no-progress --prefer-dist --optimize-autoloader
   cv ext:enable funding
 
   # For headless tests these files need to exist.

--- a/tests/phpunit/Civi/Funding/Fixtures/EntityFileFixture.php
+++ b/tests/phpunit/Civi/Funding/Fixtures/EntityFileFixture.php
@@ -19,7 +19,7 @@ declare(strict_types = 1);
 
 namespace Civi\Funding\Fixtures;
 
-use Civi\Api4\_EntityFile;
+use Civi\Api4\X_EntityFile;
 
 /**
  * @phpstan-type entityFileT array{
@@ -35,7 +35,7 @@ final class EntityFileFixture {
    * @phpstan-return entityFileT
    */
   public static function addFixture(string $entityTable, int $entityId, int $fileId): array {
-    $action = _EntityFile::create(FALSE)
+    $action = X_EntityFile::create(FALSE)
       ->setValues([
         'entity_table' => $entityTable,
         'entity_id' => $entityId,


### PR DESCRIPTION
When the class name begins with an underscore it leads to this error
with CiviCRM >=5.67:
`PHP Fatal error:  Cannot declare class Civi\Api4\EntityFile, because the
name is already in use`