### PR TITLE
Prevent autowiring of required action parameters

### DIFF
--- a/Civi/Funding/DependencyInjection/Compiler/ActionPropertyAutowireFixPass.php
+++ b/Civi/Funding/DependencyInjection/Compiler/ActionPropertyAutowireFixPass.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types = 1);
+
+namespace Civi\Funding\DependencyInjection\Compiler;
+
+use Civi\Api4\Generic\AbstractAction;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Symfony DI tries to autowire properties annotated with @required. Though
+ * CiviCRM actions parameters can be annotated in this way to make them
+ * required. This pass clears the properties that are going to be injected for
+ * action classes registered as service in the Civi\Funding\Api4\Action
+ * namespace.
+ *
+ * @see https://github.com/symfony/symfony/pull/52910
+ */
+final class ActionPropertyAutowireFixPass implements CompilerPassInterface {
+
+  public function process(ContainerBuilder $container): void {
+    foreach ($container->getDefinitions() as $id => $definition) {
+      if ([] === $definition->getProperties() || !str_starts_with($id, 'Civi\\Funding\\Api4\\Action\\')) {
+        continue;
+      }
+
+      if (is_a($id, AbstractAction::class, TRUE)) {
+        $definition->setProperties([]);
+      }
+    }
+  }
+
+}

--- a/services/other.php
+++ b/services/other.php
@@ -27,6 +27,7 @@ use Civi\Funding\Contact\FundingRemoteContactIdResolverInterface;
 use Civi\Funding\Controller\PageControllerInterface;
 use Civi\Funding\ControllerDectorator\TransactionalPageController;
 use Civi\Funding\Database\ChangeSetFactory;
+use Civi\Funding\DependencyInjection\Compiler\ActionPropertyAutowireFixPass;
 use Civi\Funding\DependencyInjection\Compiler\EntityValidatorPass;
 use Civi\Funding\DependencyInjection\Compiler\FundingCaseTypeServiceLocatorPass;
 use Civi\Funding\DependencyInjection\Util\ServiceRegistrator;
@@ -42,6 +43,7 @@ use Civi\Funding\Util\MoneyFactory;
 use Civi\Funding\Util\UrlGenerator;
 use Civi\Funding\Validation\EntityValidator;
 use Civi\Funding\Validation\EntityValidatorInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -58,6 +60,7 @@ $container->autowire(UrlGenerator::class);
 $container->autowire(MoneyFactory::class);
 $container->autowire(ChangeSetFactory::class);
 
+$container->addCompilerPass(new ActionPropertyAutowireFixPass(), PassConfig::TYPE_BEFORE_REMOVING);
 $container->addCompilerPass(new FundingCaseTypeServiceLocatorPass());
 
 $container->autowire(FundingRemoteContactIdResolverInterface::class, FundingRemoteContactIdResolver::class);


### PR DESCRIPTION
Symfony DI tries to autowire properties annotated with `@required`. Though CiviCRM action parameters can be annotated in this way to make them required.

https://github.com/symfony/symfony/pull/52910 would fix this in Symfony and make the custom compiler pass unnecessary.

Fixes #176.