### PR TITLE
SammelantragKurs: Skip re-review under certain conditions

### DIFF
--- a/Civi/Funding/EventSubscriber/ApplicationProcess/ApplicationProcessEligibleSubscriber.php
+++ b/Civi/Funding/EventSubscriber/ApplicationProcess/ApplicationProcessEligibleSubscriber.php
@@ -35,9 +35,10 @@ final class ApplicationProcessEligibleSubscriber implements EventSubscriberInter
    * @inheritDoc
    */
   public static function getSubscribedEvents(): array {
+    // Priority is decreased so other subscribers can change the status before.
     return [
-      ApplicationProcessPreCreateEvent::class => 'onPreCreate',
-      ApplicationProcessPreUpdateEvent::class => 'onPreUpdate',
+      ApplicationProcessPreCreateEvent::class => ['onPreCreate', -100],
+      ApplicationProcessPreUpdateEvent::class => ['onPreUpdate', -100],
     ];
   }
 

--- a/Civi/Funding/SammelantragKurs/EventSubscriber/KursApplicationStatusSubscriber.php
+++ b/Civi/Funding/SammelantragKurs/EventSubscriber/KursApplicationStatusSubscriber.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Funding\SammelantragKurs\EventSubscriber;
+
+use Civi\Funding\ApplicationProcess\ApplicationProcessManager;
+use Civi\Funding\ApplicationProcess\ApplicationSnapshotManager;
+use Civi\Funding\Event\ApplicationProcess\ApplicationProcessPreUpdateEvent;
+use Civi\Funding\SammelantragKurs\KursConstants;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Applications in this funding case type can be modified without a new review
+ * under these conditions:
+ *   - The title is not changed.
+ *   - The short description is not changed.
+ *   - The amount requested is not increased, or the new sum of the amounts
+ *     requested of all (possibly) eligible applications in the same funding
+ *     case doesn't exceed the amount approved.
+ *
+ * This subscriber ensures that under those conditions the status is changed to
+ * "eligible" instead of "rework-review-requested".
+ */
+final class KursApplicationStatusSubscriber implements EventSubscriberInterface {
+
+  private ApplicationProcessManager $applicationProcessManager;
+
+  private ApplicationSnapshotManager $snapshotManager;
+
+  /**
+   * @inheritDoc
+   */
+  public static function getSubscribedEvents(): array {
+    return [ApplicationProcessPreUpdateEvent::class => 'onPreUpdate'];
+  }
+
+  public function __construct(
+    ApplicationProcessManager $applicationProcessManager,
+    ApplicationSnapshotManager $snapshotManager
+  ) {
+    $this->applicationProcessManager = $applicationProcessManager;
+    $this->snapshotManager = $snapshotManager;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function onPreUpdate(ApplicationProcessPreUpdateEvent $event): void {
+    if ($event->getFundingCaseType()->getName() !== KursConstants::FUNDING_CASE_TYPE_NAME) {
+      return;
+    }
+
+    $applicationProcess = $event->getApplicationProcess();
+    if ($applicationProcess->getStatus() === 'rework-review-requested'
+      && $applicationProcess->getStatus() !== $event->getPreviousApplicationProcess()->getStatus()
+    ) {
+      if (!$this->isReviewRequired($event)) {
+        $applicationProcess->setStatus('eligible');
+      }
+    }
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  private function isReviewRequired(ApplicationProcessPreUpdateEvent $event): bool {
+    $applicationProcess = $event->getApplicationProcess();
+    $snapshot = $this->snapshotManager->getLastByApplicationProcessId($applicationProcess->getId());
+    if (NULL === $snapshot) {
+      // Should not happen.
+      return TRUE;
+    }
+
+    if ($applicationProcess->getTitle() !== $snapshot->getTitle()
+      || $applicationProcess->getShortDescription() !== $snapshot->getShortDescription()) {
+      return TRUE;
+    }
+
+    if ($applicationProcess->getAmountRequested() <= $snapshot->getAmountRequested()) {
+      return FALSE;
+    }
+
+    return $this->getSumAmountRequested($event) > ($event->getFundingCase()->getAmountApproved() ?? 0);
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  private function getSumAmountRequested(ApplicationProcessPreUpdateEvent $event): float {
+    $updatedApplicationProcessId = $event->getApplicationProcess()->getId();
+    $sumAmountRequested = $event->getApplicationProcess()->getAmountRequested();
+
+    $fundingCaseId = $event->getFundingCase()->getId();
+    foreach ($this->applicationProcessManager->getByFundingCaseId($fundingCaseId) as $applicationProcess) {
+      if ($applicationProcess->getId() !== $updatedApplicationProcessId
+        && FALSE !== $applicationProcess->getIsEligible()
+      ) {
+        $sumAmountRequested += $applicationProcess->getAmountRequested();
+      }
+    }
+
+    return $sumAmountRequested;
+  }
+
+}

--- a/services/z_sammelantrag-kurs.php
+++ b/services/z_sammelantrag-kurs.php
@@ -34,6 +34,7 @@ use Civi\Funding\SammelantragKurs\Application\Data\KursApplicationResourcesItems
 use Civi\Funding\SammelantragKurs\Application\JsonSchema\KursApplicationJsonSchemaFactory;
 use Civi\Funding\SammelantragKurs\Application\UiSchema\KursApplicationUiSchemaFactory;
 use Civi\Funding\SammelantragKurs\Application\Validation\KursApplicationValidator;
+use Civi\Funding\SammelantragKurs\EventSubscriber\KursApplicationStatusSubscriber;
 use Civi\Funding\SammelantragKurs\FundingCase\Actions\KursCaseActionsDeterminer;
 use Civi\Funding\SammelantragKurs\FundingCase\Actions\KursCaseSubmitActionsContainer;
 use Civi\Funding\SammelantragKurs\FundingCase\Actions\KursCaseSubmitActionsFactory;
@@ -84,3 +85,7 @@ $container->autowire(KursApplicationResourcesItemsFactory::class)
   ->addTag(KursApplicationResourcesItemsFactory::SERVICE_TAG);
 $container->autowire(KursApplicationFormFilesFactory::class)
   ->addTag(KursApplicationFormFilesFactory::SERVICE_TAG);
+
+$container->autowire(KursApplicationStatusSubscriber::class)
+  ->addTag('kernel.event_subscriber')
+  ->setLazy(TRUE);

--- a/tests/phpunit/Civi/Funding/EventSubscriber/ApplicationProcess/ApplicationProcessEligibleSubscriberTest.php
+++ b/tests/phpunit/Civi/Funding/EventSubscriber/ApplicationProcess/ApplicationProcessEligibleSubscriberTest.php
@@ -53,13 +53,13 @@ final class ApplicationProcessEligibleSubscriberTest extends TestCase {
 
   public function testGetSubscribedEvents(): void {
     $expectedSubscriptions = [
-      ApplicationProcessPreCreateEvent::class => 'onPreCreate',
-      ApplicationProcessPreUpdateEvent::class => 'onPreUpdate',
+      ApplicationProcessPreCreateEvent::class => ['onPreCreate', -100],
+      ApplicationProcessPreUpdateEvent::class => ['onPreUpdate', -100],
     ];
 
     static::assertEquals($expectedSubscriptions, $this->subscriber::getSubscribedEvents());
 
-    foreach ($expectedSubscriptions as $method) {
+    foreach ($expectedSubscriptions as [$method, $priority]) {
       static::assertTrue(method_exists(get_class($this->subscriber), $method));
     }
   }

--- a/tests/phpunit/Civi/Funding/SammelantragKurs/EventSubscriber/KursApplicationStatusSubscriberTest.php
+++ b/tests/phpunit/Civi/Funding/SammelantragKurs/EventSubscriber/KursApplicationStatusSubscriberTest.php
@@ -1,0 +1,201 @@
+<?php
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Funding\SammelantragKurs\EventSubscriber;
+
+use Civi\Funding\ApplicationProcess\ApplicationProcessManager;
+use Civi\Funding\ApplicationProcess\ApplicationSnapshotManager;
+use Civi\Funding\EntityFactory\ApplicationProcessBundleFactory;
+use Civi\Funding\EntityFactory\ApplicationProcessFactory;
+use Civi\Funding\EntityFactory\ApplicationSnapshotFactory;
+use Civi\Funding\Event\ApplicationProcess\ApplicationProcessPreUpdateEvent;
+use Civi\Funding\SammelantragKurs\KursConstants;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\Funding\SammelantragKurs\EventSubscriber\KursApplicationStatusSubscriber
+ */
+final class KursApplicationStatusSubscriberTest extends TestCase {
+
+  /**
+   * @var \Civi\Funding\ApplicationProcess\ApplicationProcessManager&\PHPUnit\Framework\MockObject\MockObject
+   */
+  private MockObject $applicationProcessManagerMock;
+
+  /**
+   * @var \Civi\Funding\ApplicationProcess\ApplicationSnapshotManager&\PHPUnit\Framework\MockObject\MockObject
+   */
+  private MockObject $snapshotManagerMock;
+
+  private KursApplicationStatusSubscriber $subscriber;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->applicationProcessManagerMock = $this->createMock(ApplicationProcessManager::class);
+    $this->snapshotManagerMock = $this->createMock(ApplicationSnapshotManager::class);
+    $this->subscriber = new KursApplicationStatusSubscriber(
+      $this->applicationProcessManagerMock,
+      $this->snapshotManagerMock
+    );
+  }
+
+  public function testGetSubscribedEvents(): void {
+    $expectedSubscriptions = [
+      ApplicationProcessPreUpdateEvent::class => 'onPreUpdate',
+    ];
+
+    static::assertEquals($expectedSubscriptions, $this->subscriber::getSubscribedEvents());
+
+    foreach ($expectedSubscriptions as $method) {
+      static::assertTrue(method_exists(get_class($this->subscriber), $method));
+    }
+  }
+
+  public function testTitleChanged(): void {
+    $event = $this->createPreUpdateEvent(['title' => ['old', 'new']]);
+    $this->subscriber->onPreUpdate($event);
+    static::assertSame('rework-review-requested', $event->getApplicationProcess()->getStatus());
+  }
+
+  public function testShortDescriptionChanged(): void {
+    $event = $this->createPreUpdateEvent(['short_description' => ['old', 'new']]);
+    $this->subscriber->onPreUpdate($event);
+    static::assertSame('rework-review-requested', $event->getApplicationProcess()->getStatus());
+  }
+
+  public function testAmountRequestedIncreasedAmountApprovedExceeded(): void {
+    $event = $this->createPreUpdateEvent(['amount_requested' => [100.1, 201.0]]);
+    $event->getFundingCase()->setAmountApproved(210);
+    $applicationProcessId = $event->getApplicationProcess()->getId();
+
+    $this->applicationProcessManagerMock->method('getByFundingCaseId')
+      ->with($event->getFundingCase()->getId())
+      ->willReturn([
+        ApplicationProcessFactory::createApplicationProcess([
+          'id' => $applicationProcessId + 1,
+          'amount_requested' => 1.23,
+          'is_eligible' => FALSE,
+        ]),
+        ApplicationProcessFactory::createApplicationProcess([
+          'id' => $applicationProcessId + 1,
+          'amount_requested' => 10.0,
+        ]),
+        $event->getPreviousApplicationProcess(),
+      ]);
+
+    $this->subscriber->onPreUpdate($event);
+    static::assertSame('rework-review-requested', $event->getApplicationProcess()->getStatus());
+  }
+
+  public function testAmountRequestedIncreasedAmountApprovedNotExceeded(): void {
+    $event = $this->createPreUpdateEvent(['amount_requested' => [100.1, 200.1]]);
+    $event->getFundingCase()->setAmountApproved(210.1);
+    $applicationProcessId = $event->getApplicationProcess()->getId();
+
+    $this->applicationProcessManagerMock->method('getByFundingCaseId')
+      ->with($event->getFundingCase()->getId())
+      ->willReturn([
+        ApplicationProcessFactory::createApplicationProcess([
+          'id' => $applicationProcessId + 1,
+          'amount_requested' => 1.23,
+          'is_eligible' => FALSE,
+        ]),
+        ApplicationProcessFactory::createApplicationProcess([
+          'id' => $applicationProcessId + 1,
+          'amount_requested' => 10.0,
+        ]),
+        $event->getPreviousApplicationProcess(),
+      ]);
+
+    $this->subscriber->onPreUpdate($event);
+    static::assertSame('eligible', $event->getApplicationProcess()->getStatus());
+  }
+
+  public function testStartDateChanged(): void {
+    // If neither title, nor short description, nor amount requested is changed,
+    // a review is not required.
+    $event = $this->createPreUpdateEvent(['start_date' => [new \DateTime('2024-01-08'), new \DateTime('2024-01-09')]]);
+    $event->getFundingCase()->setAmountApproved(210);
+
+    $this->applicationProcessManagerMock->expects(static::never())->method('getByFundingCaseId');
+
+    $this->subscriber->onPreUpdate($event);
+    static::assertSame('eligible', $event->getApplicationProcess()->getStatus());
+  }
+
+  public function testNonKursFundingCase(): void {
+    $event = $this->createPreUpdateEvent(
+      ['start_date' => [new \DateTime('2024-01-08'), new \DateTime('2024-01-09')]],
+      'FundingCaseType'
+    );
+    $event->getFundingCase()->setAmountApproved(210);
+
+    $this->applicationProcessManagerMock->expects(static::never())->method('getByFundingCaseId');
+
+    $this->subscriber->onPreUpdate($event);
+    static::assertSame('rework-review-requested', $event->getApplicationProcess()->getStatus());
+  }
+
+  public function testNotReworkReviewRequested(): void {
+    $event = $this->createPreUpdateEvent([
+      'status' => ['draft', 'applied'],
+      'start_date' => [new \DateTime('2024-01-08'), new \DateTime('2024-01-09')],
+    ]);
+    $event->getFundingCase()->setAmountApproved(210);
+
+    $this->applicationProcessManagerMock->expects(static::never())->method('getByFundingCaseId');
+
+    $this->subscriber->onPreUpdate($event);
+    static::assertSame('applied', $event->getApplicationProcess()->getStatus());
+  }
+
+  /**
+   * @phpstan-param array<string, array<mixed, mixed>> $changeSet
+   */
+  private function createPreUpdateEvent(
+    array $changeSet,
+    string $fundingCaseTypeName = KursConstants::FUNDING_CASE_TYPE_NAME
+  ): ApplicationProcessPreUpdateEvent {
+    $changeSet['status'] ??= ['rework', 'rework-review-requested'];
+    $previousValues = array_map(fn(array $oldAndNew) => $oldAndNew[0], $changeSet);
+    $currentValues = array_map(fn(array $oldAndNew) => $oldAndNew[1], $changeSet);
+
+    // @phpstan-ignore-next-line
+    $previousApplicationProcess = ApplicationProcessFactory::createApplicationProcess($previousValues);
+    $applicationProcessBundle = ApplicationProcessBundleFactory::createApplicationProcessBundle(
+      // @phpstan-ignore-next-line
+      $currentValues,
+      [],
+      ['name' => $fundingCaseTypeName]
+    );
+
+    $snapshot = ApplicationSnapshotFactory::createApplicationSnapshot($previousApplicationProcess->toArray());
+    $this->snapshotManagerMock->method('getLastByApplicationProcessId')
+      ->with($snapshot->getApplicationProcessId())
+      ->willReturn($snapshot);
+
+    return new ApplicationProcessPreUpdateEvent(
+      1,
+      $previousApplicationProcess,
+      $applicationProcessBundle,
+    );
+  }
+
+}


### PR DESCRIPTION
See comment of `KursApplicationStatusSubscriber` for details.

If it is a common use case that a new application process status depends not only on the status and the action we should consider changing the interface of the status determiner...

systopia-reference: 23630