### PR TITLE
Set `max-age` directive in `Cache-Control` header

### DIFF
--- a/Civi/Funding/Controller/PaymentInstructionDownloadController.php
+++ b/Civi/Funding/Controller/PaymentInstructionDownloadController.php
@@ -86,7 +86,8 @@ final class PaymentInstructionDownloadController implements PageControllerInterf
       Response::HTTP_OK,
       $headers,
       FALSE,
-    ))->setContentDisposition(ResponseHeaderBag::DISPOSITION_INLINE, $filename);
+    ))->setContentDisposition(ResponseHeaderBag::DISPOSITION_INLINE, $filename)
+      ->setMaxAge(300);
   }
 
 }

--- a/Civi/Funding/Controller/TransferContractDownloadController.php
+++ b/Civi/Funding/Controller/TransferContractDownloadController.php
@@ -89,8 +89,8 @@ final class TransferContractDownloadController implements PageControllerInterfac
       Response::HTTP_OK,
       $headers,
       FALSE,
-    ))->setContentDisposition(ResponseHeaderBag::DISPOSITION_INLINE, $filename);
-
+    ))->setContentDisposition(ResponseHeaderBag::DISPOSITION_INLINE, $filename)
+      ->setMaxAge(0);
   }
 
 }


### PR DESCRIPTION
If `max-age` is not given, browsers may use a heuristic freshness lifetime (RFC 9111 4.2.1)

systopia-reference: 24037