### PR TITLE
Fixup int/bool drupal/php/civi mixup

### DIFF
--- a/Civi/Funding/Api4/Action/FundingCaseInfo/GetAction.php
+++ b/Civi/Funding/Api4/Action/FundingCaseInfo/GetAction.php
@@ -104,7 +104,7 @@ final class GetAction extends AbstractGetAction {
       'funding_case_modification_date' => $fundingCase->getModificationDate()->format('Y-m-d H:i:s'),
       'funding_case_amount_approved' => $fundingCase->getAmountApproved(),
       'funding_case_type_id' => $fundingCaseType->getId(),
-      'funding_case_type_is_combined_application' => $fundingCaseType->getIsCombinedApplication(),
+      'funding_case_type_is_combined_application' => (int) $fundingCaseType->getIsCombinedApplication(),
       'funding_case_transfer_contract_uri' => $fundingCase->getTransferContractUri(),
       'funding_program_id' => $fundingProgram->getId(),
       'funding_program_currency' => $fundingProgram->getCurrency(),


### PR DESCRIPTION
Error: Although there are two different views for combined and non-combined cases, only combined applications are displayed in both views (in conjunction with Civi Remote Funding) (CaseType flag is_combined_application set to 1). Apparently this is partly due to the operator in the non-combined view (!= 1 instead of = 0) and partly due to a faulty comparison with the Boolean.
At times we had the feeling that we had gone crazy.
