### PR TITLE
ServiceRegistrator: Share services by default

### DIFF
--- a/Civi/Funding/DependencyInjection/Util/ServiceRegistrator.php
+++ b/Civi/Funding/DependencyInjection/Util/ServiceRegistrator.php
@@ -118,7 +118,7 @@ final class ServiceRegistrator {
           /** @phpstan-var class-string $class */
           $definition = $container->autowire($class);
           $definition->setLazy(self::isServiceLazy($class, $options));
-          $definition->setShared($options['shared'] ?? FALSE);
+          $definition->setShared($options['shared'] ?? TRUE);
           $definition->setPublic($options['public'] ?? FALSE);
           foreach ($tags as $tagName => $tagAttributes) {
             $definition->addTag($tagName, $tagAttributes);


### PR DESCRIPTION
The default was wrongly set to `FALSE`.