### PR TITLE
Create cost/resources items for amount `0`

### DIFF
--- a/Civi/Funding/ApplicationProcess/JsonSchema/CostItem/CostItemKeywordValidator.php
+++ b/Civi/Funding/ApplicationProcess/JsonSchema/CostItem/CostItemKeywordValidator.php
@@ -86,7 +86,7 @@ final class CostItemKeywordValidator extends AbstractKeywordValidator {
   private function collectCostItemData(ValidationContext $context): ?ValidationError {
     try {
       $costItemData = $this->costItemDataFactory->createCostItemData($context);
-      if (NULL === $costItemData || $costItemData->getAmount() === 0.0) {
+      if (NULL === $costItemData) {
         return NULL;
       }
 

--- a/Civi/Funding/ApplicationProcess/JsonSchema/ResourcesItem/ResourcesItemKeywordValidator.php
+++ b/Civi/Funding/ApplicationProcess/JsonSchema/ResourcesItem/ResourcesItemKeywordValidator.php
@@ -86,7 +86,7 @@ final class ResourcesItemKeywordValidator extends AbstractKeywordValidator {
   private function collectResourcesItemData(ValidationContext $context): ?ValidationError {
     try {
       $resourcesItemData = $this->resourcesItemDataFactory->createResourcesItemData($context);
-      if (NULL === $resourcesItemData || $resourcesItemData->getAmount() === 0.0) {
+      if (NULL === $resourcesItemData) {
         return NULL;
       }
 

--- a/tests/phpunit/Civi/Funding/ApplicationProcess/JsonSchema/CostItem/CostItemKeywordTest.php
+++ b/tests/phpunit/Civi/Funding/ApplicationProcess/JsonSchema/CostItem/CostItemKeywordTest.php
@@ -128,35 +128,6 @@ final class CostItemKeywordTest extends TestCase {
     );
   }
 
-  public function testZero(): void {
-    $jsonSchema = new JsonSchemaObject([
-      'costs' => new JsonSchemaObject([
-        'amount1' => new JsonSchemaNumber([
-          '$costItem' => new JsonSchemaCostItem([
-            'type' => 'foo',
-            'identifier' => 'bar',
-            'clearing' => ['itemLabel' => 'label'],
-          ]),
-        ]),
-      ]),
-    ]);
-
-    $data = (object) [
-      'costs' => (object) [
-        'amount1' => 0.0,
-      ],
-    ];
-
-    $result = $this->validator->validate(
-      $data,
-      $jsonSchema->toStdClass(),
-      ['costItemDataCollector' => $this->costItemDataCollector],
-    );
-
-    static::assertTrue($result->isValid());
-    static::assertEquals([], $this->costItemDataCollector->getCostItemsData());
-  }
-
   public function testNull(): void {
     $jsonSchema = new JsonSchemaObject([
       'costs' => new JsonSchemaObject([

--- a/tests/phpunit/Civi/Funding/ApplicationProcess/JsonSchema/ResourcesItem/ResourcesItemKeywordTest.php
+++ b/tests/phpunit/Civi/Funding/ApplicationProcess/JsonSchema/ResourcesItem/ResourcesItemKeywordTest.php
@@ -128,35 +128,6 @@ final class ResourcesItemKeywordTest extends TestCase {
     );
   }
 
-  public function testZero(): void {
-    $jsonSchema = new JsonSchemaObject([
-      'resources' => new JsonSchemaObject([
-        'amount1' => new JsonSchemaNumber([
-          '$resourcesItem' => new JsonSchemaResourcesItem([
-            'type' => 'foo',
-            'identifier' => 'bar',
-            'clearing' => ['itemLabel' => 'label'],
-          ]),
-        ]),
-      ]),
-    ]);
-
-    $data = (object) [
-      'resources' => (object) [
-        'amount1' => 0.0,
-      ],
-    ];
-
-    $result = $this->validator->validate(
-      $data,
-      $jsonSchema->toStdClass(),
-      ['resourcesItemDataCollector' => $this->resourcesItemDataCollector],
-    );
-
-    static::assertTrue($result->isValid());
-    static::assertEquals([], $this->resourcesItemDataCollector->getResourcesItemsData());
-  }
-
   public function testNull(): void {
     $jsonSchema = new JsonSchemaObject([
       'resources' => new JsonSchemaObject([


### PR DESCRIPTION
This allows to add receipts in the clearing even if no cost or resource was planned.

systopia-reference: 24794