### PR TITLE
Fix timestamp columns

### DIFF
--- a/sql/auto_install.sql
+++ b/sql/auto_install.sql
@@ -15,6 +15,10 @@
 -- *
 -- *******************************************************/
 
+-- DON'T DROP THIS LINE as long as MariaDB <= 10.9 is supported!
+-- https://mariadb.com/kb/en/server-system-variables/#explicit_defaults_for_timestamp
+SET SESSION explicit_defaults_for_timestamp=ON;
+
 SET FOREIGN_KEY_CHECKS=0;
 
 DROP TABLE IF EXISTS `civicrm_funding_clearing_cost_item`;

--- a/sql/upgrade/0002.sql
+++ b/sql/upgrade/0002.sql
@@ -1,3 +1,21 @@
+-- Fix timestamp columns in MariaDB <= 10.9
+-- https://mariadb.com/kb/en/server-system-variables/#explicit_defaults_for_timestamp
+SET SESSION explicit_defaults_for_timestamp=ON;
+
+ALTER TABLE civicrm_funding_case
+  MODIFY creation_date TIMESTAMP NOT NULL,
+  MODIFY modification_date TIMESTAMP NOT NULL;
+
+ALTER TABLE civicrm_funding_application_process
+  MODIFY creation_date TIMESTAMP NOT NULL,
+  MODIFY modification_date TIMESTAMP NOT NULL;
+
+ALTER TABLE civicrm_funding_application_snapshot
+  MODIFY creation_date TIMESTAMP NOT NULL;
+
+ALTER TABLE civicrm_funding_drawdown
+  MODIFY creation_date TIMESTAMP NOT NULL;
+
 CREATE TABLE `civicrm_funding_clearing_process` (
   `id` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique FundingClearingProcess ID',
   `application_process_id` int unsigned NOT NULL COMMENT 'FK to FundingApplicationProcess',


### PR DESCRIPTION
Because of the behavior described in
https://mariadb.com/kb/en/server-system-variables/#explicit_defaults_for_timestamp database columns of type "TIMESTAMP NOT NULL" are not as expected.

systopia-reference: 25209