### PR TITLE
Don't depend on `symfony/cache`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         "sort-packages": true
     },
     "require": {
-        "symfony/cache": "^5",
-        "symfony/http-foundation": " ^4 || ^5 || ^6",
-        "symfony/http-kernel": " ^4 || ^5 || ^6",
+        "psr/simple-cache": "^1 || ^2 || ^3",
+        "symfony/http-foundation": " ^4.4 || ^5 || ^6",
+        "symfony/http-kernel": " ^4.4 || ^5 || ^6",
         "symfony/polyfill-php80": ">=1",
-        "symfony/property-access": "^5||^6",
+        "symfony/property-access": "^5 || ^6",
         "webmozart/assert": "^1.10"
     },
     "require-dev": {


### PR DESCRIPTION
`symfony/cache` was listed as dependency, though not actually required.

Fixes #292.