### PR TITLE
SammelantragKurs: Fix mapping of JSON data to `ApplicationProcess` fields

### DIFF
--- a/Civi/Funding/ApplicationProcess/JsonSchema/Validator/OpisApplicationValidatorFactory.php
+++ b/Civi/Funding/ApplicationProcess/JsonSchema/Validator/OpisApplicationValidatorFactory.php
@@ -33,6 +33,7 @@ final class OpisApplicationValidatorFactory {
     if (!isset(self::$validator)) {
       $expressionHandler = new SymfonyExpressionHandler(new SystopiaExpressionLanguage());
       self::$validator = new OpisApplicationValidator([
+        'convertEmptyArrays' => TRUE,
         'calculator' => $expressionHandler,
         'evaluator' => $expressionHandler,
       ]);

--- a/Civi/Funding/SammelantragKurs/Application/JsonSchema/KursGrunddatenJsonSchema.php
+++ b/Civi/Funding/SammelantragKurs/Application/JsonSchema/KursGrunddatenJsonSchema.php
@@ -39,17 +39,24 @@ final class KursGrunddatenJsonSchema extends JsonSchemaObject {
     bool $report = FALSE
   ) {
     $properties = [
-      'titel' => new JsonSchemaString(),
-      'kurzbeschreibungDerInhalte' => new JsonSchemaString(['maxLength' => 500]),
+      'titel' => new JsonSchemaString([
+        '$tag' => JsonSchema::fromArray(['mapToField' => ['fieldName' => 'title']]),
+      ]),
+      'kurzbeschreibungDerInhalte' => new JsonSchemaString([
+        'maxLength' => 500,
+        '$tag' => JsonSchema::fromArray(['mapToField' => ['fieldName' => 'short_description']]),
+      ]),
       'zeitraeume' => new JsonSchemaArray(
         new JsonSchemaObject([
           'beginn' => new JsonSchemaDate([
             'minDate' => $applicationBegin->format('Y-m-d'),
             'maxDate' => $applicationEnd->format('Y-m-d'),
+            '$tag' => JsonSchema::fromArray(['mapToField' => ['fieldName' => 'start_date', 'replace' => FALSE]]),
           ]),
           'ende' => new JsonSchemaDate([
             'minDate' => new JsonSchemaDataPointer('1/beginn', '0000-00-00'),
             'maxDate' => $applicationEnd->format('Y-m-d'),
+            '$tag' => JsonSchema::fromArray(['mapToField' => ['fieldName' => 'end_date']]),
           ]),
         ],
           [

--- a/Civi/Funding/SammelantragKurs/Application/JsonSchema/KursZuschussJsonSchema.php
+++ b/Civi/Funding/SammelantragKurs/Application/JsonSchema/KursZuschussJsonSchema.php
@@ -20,6 +20,7 @@ declare(strict_types = 1);
 namespace Civi\Funding\SammelantragKurs\Application\JsonSchema;
 
 use Civi\Funding\ApplicationProcess\JsonSchema\CostItem\JsonSchemaCostItem;
+use Civi\RemoteTools\JsonSchema\JsonSchema;
 use Civi\RemoteTools\JsonSchema\JsonSchemaCalculate;
 use Civi\RemoteTools\JsonSchema\JsonSchemaDataPointer;
 use Civi\RemoteTools\JsonSchema\JsonSchemaMoney;
@@ -141,7 +142,7 @@ final class KursZuschussJsonSchema extends JsonSchemaObject {
             '1/honorarkosten',
             new JsonSchemaDataPointer('1/honorarkostenMax'),
           ),
-        ],
+        ], NULL, ['$tag' => JsonSchema::fromArray(['mapToField' => ['fieldName' => 'amount_requested']])]
       ),
     ];
 

--- a/tests/phpunit/Civi/Funding/IJB/Application/JsonSchema/IJBApplicationJsonSchemaTest.php
+++ b/tests/phpunit/Civi/Funding/IJB/Application/JsonSchema/IJBApplicationJsonSchemaTest.php
@@ -22,6 +22,7 @@ namespace Civi\Funding\IJB\Application\JsonSchema;
 use Civi\Funding\ApplicationProcess\JsonSchema\Validator\ApplicationSchemaValidator;
 use Civi\Funding\ApplicationProcess\JsonSchema\Validator\OpisApplicationValidatorFactory;
 use Civi\Funding\Form\JsonSchema\JsonSchemaRecipient;
+use Civi\Funding\Form\MappedData\MappedDataLoader;
 use Civi\Funding\Form\Traits\AssertFormTrait;
 use Civi\Funding\Validation\Traits\AssertValidationResultTrait;
 use Civi\RemoteTools\JsonSchema\JsonSchema;
@@ -142,12 +143,12 @@ final class IJBApplicationJsonSchemaTest extends TestCase {
         'kurzbeschreibungDesInhalts' => 'foo bar',
         'zeitraeume' => [
           [
-            'beginn' => '2022-08-24',
-            'ende' => '2022-08-24',
-          ],
-          [
             'beginn' => '2022-08-25',
             'ende' => '2022-08-26',
+          ],
+          [
+            'beginn' => '2022-08-24',
+            'ende' => '2022-08-24',
           ],
         ],
         'artDerMassnahme' => 'fachkraefteprogramm',
@@ -338,6 +339,17 @@ final class IJBApplicationJsonSchemaTest extends TestCase {
     );
 
     static::assertAllPropertiesSet($jsonSchema->toStdClass(), $resultData);
+
+    $mappedDataLoader = new MappedDataLoader();
+    $mappedData = $mappedDataLoader->getMappedData($result->getTaggedData());
+    static::assertEquals([
+      'title' => 'Test',
+      'short_description' => 'foo bar',
+      'recipient_contact_id' => 2,
+      'start_date' => '2022-08-24',
+      'end_date' => '2022-08-26',
+      'amount_requested' => $zuschussGesamt,
+    ], $mappedData);
   }
 
   public function testFachkraefteprogrammPartnerland(): void {
@@ -618,6 +630,17 @@ final class IJBApplicationJsonSchemaTest extends TestCase {
     );
 
     static::assertAllPropertiesSet($jsonSchema->toStdClass(), $resultData);
+
+    $mappedDataLoader = new MappedDataLoader();
+    $mappedData = $mappedDataLoader->getMappedData($result->getTaggedData());
+    static::assertEquals([
+      'title' => 'Test',
+      'short_description' => 'foo bar',
+      'recipient_contact_id' => 2,
+      'start_date' => '2022-08-24',
+      'end_date' => '2022-08-26',
+      'amount_requested' => $zuschussGesamt,
+    ], $mappedData);
   }
 
   public function testJugendbegegnungDeutschland(): void {
@@ -904,6 +927,17 @@ final class IJBApplicationJsonSchemaTest extends TestCase {
     );
 
     static::assertAllPropertiesSet($jsonSchema->toStdClass(), $resultData);
+
+    $mappedDataLoader = new MappedDataLoader();
+    $mappedData = $mappedDataLoader->getMappedData($result->getTaggedData());
+    static::assertEquals([
+      'title' => 'Test',
+      'short_description' => 'foo bar',
+      'recipient_contact_id' => 2,
+      'start_date' => '2022-08-24',
+      'end_date' => '2022-08-26',
+      'amount_requested' => $zuschussGesamt,
+    ], $mappedData);
   }
 
   public function testJugendbegegnungPartnerland(): void {
@@ -1184,6 +1218,17 @@ final class IJBApplicationJsonSchemaTest extends TestCase {
     );
 
     static::assertAllPropertiesSet($jsonSchema->toStdClass(), $resultData);
+
+    $mappedDataLoader = new MappedDataLoader();
+    $mappedData = $mappedDataLoader->getMappedData($result->getTaggedData());
+    static::assertEquals([
+      'title' => 'Test',
+      'short_description' => 'foo bar',
+      'recipient_contact_id' => 2,
+      'start_date' => '2022-08-24',
+      'end_date' => '2022-08-26',
+      'amount_requested' => $zuschussGesamt,
+    ], $mappedData);
   }
 
   public function testFinanzierungNichtAusgeglichen(): void {


### PR DESCRIPTION
This was missing in #297.