### PR TITLE
Fix calculation of "programmtage"

### DIFF
--- a/Civi/Funding/IJB/Application/JsonSchema/IJBGrunddatenJsonSchema.php
+++ b/Civi/Funding/IJB/Application/JsonSchema/IJBGrunddatenJsonSchema.php
@@ -71,7 +71,15 @@ final class IJBGrunddatenJsonSchema extends JsonSchemaObject {
       ),
       'programmtage' => new JsonSchemaCalculate(
         'number',
-        'sum(map(zeitraeume, "date_create(value.beginn).diff(date_create(value.ende)).days + 1"))',
+        <<<'EOD'
+sum(
+  map(zeitraeume, "
+    value.beginn && value.ende
+    ? date_create(value.beginn).diff(date_create(value.ende)).days + 1
+    : 0
+  ")
+)
+EOD,
         ['zeitraeume' => new JsonSchemaDataPointer('1/zeitraeume')],
         0
       ),

--- a/Civi/Funding/SammelantragKurs/Application/JsonSchema/KursGrunddatenJsonSchema.php
+++ b/Civi/Funding/SammelantragKurs/Application/JsonSchema/KursGrunddatenJsonSchema.php
@@ -70,7 +70,15 @@ final class KursGrunddatenJsonSchema extends JsonSchemaObject {
       ),
       'programmtage' => new JsonSchemaCalculate(
         'number',
-        'sum(map(zeitraeume, "date_create(value.beginn).diff(date_create(value.ende)).days + 1"))',
+        <<<'EOD'
+sum(
+  map(zeitraeume, "
+    value.beginn && value.ende
+    ? date_create(value.beginn).diff(date_create(value.ende)).days + 1
+    : 0
+  ")
+)
+EOD,
         ['zeitraeume' => new JsonSchemaDataPointer('1/zeitraeume')],
         0
       ),


### PR DESCRIPTION
With recent versions of drupal/json_forms empty dates are converted to NULL with conflicts with the `date_create()` language expression function which expects a string.

systopia-reference: 25736