### PR TITLE
Update application actions determiner on status `complete`

### DIFF
--- a/Civi/Funding/ApplicationProcess/ActionsDeterminer/DefaultApplicationProcessActionsDeterminer.php
+++ b/Civi/Funding/ApplicationProcess/ActionsDeterminer/DefaultApplicationProcessActionsDeterminer.php
@@ -68,6 +68,8 @@ final class DefaultApplicationProcessActionsDeterminer extends AbstractApplicati
     ],
     'complete' => [
       'application_withdraw' => ['withdraw'],
+      'review_calculative' => ['update', 'add-comment'],
+      'review_content' => ['update', 'add-comment'],
     ],
   ];
 

--- a/Civi/Funding/ApplicationProcess/ActionsDeterminer/ReworkPossibleApplicationProcessActionsDeterminer.php
+++ b/Civi/Funding/ApplicationProcess/ActionsDeterminer/ReworkPossibleApplicationProcessActionsDeterminer.php
@@ -61,11 +61,6 @@ final class ReworkPossibleApplicationProcessActionsDeterminer extends AbstractAp
       'review_calculative' => ['request-change', 'update', 'reject-change', 'add-comment'],
       'review_content' => ['request-change', 'update', 'reject-change', 'add-comment'],
     ],
-    'complete' => [
-      'application_withdraw' => ['withdraw'],
-      'review_calculative' => ['update', 'add-comment'],
-      'review_content' => ['update', 'add-comment'],
-    ],
   ];
 
   private ApplicationProcessActionsDeterminerInterface $actionsDeterminer;

--- a/Civi/Funding/SammelantragKurs/Application/Actions/KursApplicationActionsDeterminer.php
+++ b/Civi/Funding/SammelantragKurs/Application/Actions/KursApplicationActionsDeterminer.php
@@ -81,6 +81,8 @@ final class KursApplicationActionsDeterminer extends AbstractApplicationProcessA
     ],
     'complete' => [
       'application_withdraw' => ['withdraw'],
+      'review_calculative' => ['update', 'add-comment'],
+      'review_content' => ['update', 'add-comment'],
     ],
   ];
 

--- a/tests/phpunit/Civi/Funding/ApplicationProcess/ActionsDeterminer/DefaultApplicationProcessActionsDeterminerTest.php
+++ b/tests/phpunit/Civi/Funding/ApplicationProcess/ActionsDeterminer/DefaultApplicationProcessActionsDeterminerTest.php
@@ -100,8 +100,8 @@ final class DefaultApplicationProcessActionsDeterminerTest extends TestCase {
       'application_modify' => [],
       'application_apply' => [],
       'application_withdraw' => ['withdraw'],
-      'review_calculative' => [],
-      'review_content' => [],
+      'review_calculative' => ['update', 'add-comment'],
+      'review_content' => ['update', 'add-comment'],
     ],
   ];
   // phpcs:enable

--- a/tests/phpunit/Civi/Funding/ApplicationProcess/ActionsDeterminer/ReworkPossibleApplicationProcessActionsDeterminerTest.php
+++ b/tests/phpunit/Civi/Funding/ApplicationProcess/ActionsDeterminer/ReworkPossibleApplicationProcessActionsDeterminerTest.php
@@ -74,9 +74,9 @@ final class ReworkPossibleApplicationProcessActionsDeterminerTest extends TestCa
       'application_modify' => [],
       'application_request_rework' => [],
       'application_apply' => [],
-      'application_withdraw' => ['withdraw'],
-      'review_calculative' => ['update', 'add-comment'],
-      'review_content' => ['update', 'add-comment'],
+      'application_withdraw' => [],
+      'review_calculative' => [],
+      'review_content' => [],
     ],
   ];
   // phpcs:enable


### PR DESCRIPTION
- Move actions from `ReworkPossibleApplicationProcessActionsDeterminer` to `DefaultApplicationProcessActionsDeterminer`
- Use the same actions in `KursApplicationActionsDeterminer`.