### PR TITLE
Allow funding case types to specify funding case status to which new application processes can be added to

### DIFF
--- a/Civi/Funding/Entity/FundingCaseTypeEntity.php
+++ b/Civi/Funding/Entity/FundingCaseTypeEntity.php
@@ -102,4 +102,23 @@ final class FundingCaseTypeEntity extends AbstractEntity {
     return $this;
   }
 
+  /**
+   * @param mixed $default
+   *
+   * @return mixed|null
+   */
+  public function getProperty(string $key, $default = NULL) {
+    return $this->values['properties'][$key] ?? $default;
+  }
+
+  /**
+   * @param mixed $value
+   *   JSON serializable.
+   */
+  public function setProperty(string $key, $value): self {
+    $this->values['properties'][$key] = $value;
+
+    return $this;
+  }
+
 }

--- a/tests/phpunit/Civi/Funding/ApplicationProcess/Handler/ApplicationFormNewSubmitHandlerTest.php
+++ b/tests/phpunit/Civi/Funding/ApplicationProcess/Handler/ApplicationFormNewSubmitHandlerTest.php
@@ -93,8 +93,8 @@ final class ApplicationFormNewSubmitHandlerTest extends TestCase {
       ->willReturn('test_status');
 
     $fundingCase = FundingCaseFactory::createFundingCase();
-    $this->fundingCaseManagerMock->expects(static::once())->method('getOpenOrCreate')
-      ->with($command->getContactId(), [
+    $this->fundingCaseManagerMock->expects(static::once())->method('getOrCreate')
+      ->with(['addable_status'], $command->getContactId(), [
         'funding_program' => $command->getFundingProgram(),
         'funding_case_type' => $command->getFundingCaseType(),
         'recipient_contact_id' => ApplicationFormValidationResultFactory::RECIPIENT_CONTACT_ID,
@@ -143,7 +143,9 @@ final class ApplicationFormNewSubmitHandlerTest extends TestCase {
   private function createCommand(): ApplicationFormNewSubmitCommand {
     return new ApplicationFormNewSubmitCommand(
       1,
-      FundingCaseTypeFactory::createFundingCaseType(),
+      FundingCaseTypeFactory::createFundingCaseType([
+        'properties' => ['applicationAddableStatusList' => ['addable_status']],
+      ]),
       FundingProgramFactory::createFundingProgram(),
       ['test' => 'foo'],
     );

--- a/tests/phpunit/Civi/Funding/Fixtures/FundingCaseTypeFixture.php
+++ b/tests/phpunit/Civi/Funding/Fixtures/FundingCaseTypeFixture.php
@@ -25,7 +25,7 @@ use Civi\Funding\Entity\FundingCaseTypeEntity;
 final class FundingCaseTypeFixture {
 
   /**
-   * @param array<string, scalar> $values
+   * @param array<string, mixed> $values
    *
    * @throws \CRM_Core_Exception
    */


### PR DESCRIPTION
Previously the funding case status to add new application processes was hard coded to `open`. Now it can be specified in the properties of the `FundingCaseType` entity with the key `applicationAddableStatusList`. The new default is now to always create a new funding case. (This change only affects non-combined funding case types.)

systopia-reference: 26279