### PR TITLE
Fix contact sub type checks

### DIFF
--- a/Civi/Funding/Contact/Relation/Loaders/ContactTypeAndRelationshipTypeLoader.php
+++ b/Civi/Funding/Contact/Relation/Loaders/ContactTypeAndRelationshipTypeLoader.php
@@ -46,14 +46,16 @@ final class ContactTypeAndRelationshipTypeLoader implements RelatedContactsLoade
     Assert::integer($relationProperties['relationshipTypeId']);
     $contactTypeId = $relationProperties['contactTypeId'];
     $relationshipTypeId = $relationProperties['relationshipTypeId'];
+    $separator = \CRM_Core_DAO::VALUE_SEPARATOR;
+
     $action = Contact::get(FALSE)
       ->addJoin('ContactType AS ct', 'INNER', NULL,
         CompositeCondition::new('AND',
           Comparison::new('ct.id', '=', $contactTypeId),
           CompositeCondition::new(
             'OR',
-            Comparison::new('ct.name', '=', 'contact_type'),
-            Comparison::new('ct.name', '=', 'contact_sub_type'),
+            Comparison::new('contact_type', '=', 'ct.name'),
+            Comparison::new('contact_sub_type', 'LIKE', "CONCAT('%${separator}', ct.name, '${separator}%')")
           ),
         )->toArray()
       )->addJoin('Relationship AS r', 'INNER', NULL,

--- a/Civi/Funding/Contact/Relation/Loaders/SelfByContactTypeLoader.php
+++ b/Civi/Funding/Contact/Relation/Loaders/SelfByContactTypeLoader.php
@@ -43,14 +43,16 @@ final class SelfByContactTypeLoader implements RelatedContactsLoaderInterface {
   public function getRelatedContacts(int $contactId, string $relationType, array $relationProperties): array {
     Assert::integer($relationProperties['contactTypeId']);
     $contactTypeId = $relationProperties['contactTypeId'];
+    $separator = \CRM_Core_DAO::VALUE_SEPARATOR;
+
     $action = Contact::get(FALSE)
       ->addJoin('ContactType AS ct', 'INNER', NULL,
         CompositeCondition::new('AND',
           Comparison::new('ct.id', '=', $contactTypeId),
           CompositeCondition::new(
             'OR',
-            Comparison::new('ct.name', '=', 'contact_type'),
-            Comparison::new('ct.name', '=', 'contact_sub_type'),
+            Comparison::new('contact_type', '=', 'ct.name'),
+            Comparison::new('contact_sub_type', 'LIKE', "CONCAT('%${separator}', ct.name, '${separator}%')")
           ),
         )->toArray(),
       )

--- a/Civi/Funding/Permission/ContactRelation/Checker/ContactTypeChecker.php
+++ b/Civi/Funding/Permission/ContactRelation/Checker/ContactTypeChecker.php
@@ -45,6 +45,7 @@ final class ContactTypeChecker implements ContactRelationCheckerInterface {
   public function hasRelation(int $contactId, string $relationType, array $relationProperties): bool {
     $contactTypeId = $relationProperties['contactTypeId'];
     Assert::numeric($contactTypeId);
+    $separator = \CRM_Core_DAO::VALUE_SEPARATOR;
 
     $action = ContactType::get(FALSE)
       ->addSelect('id')
@@ -55,7 +56,7 @@ final class ContactTypeChecker implements ContactRelationCheckerInterface {
           CompositeCondition::new(
             'OR',
             Comparison::new('c.contact_type', '=', 'name'),
-            Comparison::new('c.contact_sub_type', '=', 'name'),
+            Comparison::new('c.contact_sub_type', 'LIKE', "CONCAT('%${separator}', name, '${separator}%')")
           ),
         )->toArray(),
       );

--- a/Civi/Funding/Permission/ContactRelation/Checker/RelationshipChecker.php
+++ b/Civi/Funding/Permission/ContactRelation/Checker/RelationshipChecker.php
@@ -96,12 +96,13 @@ final class RelationshipChecker implements ContactRelationCheckerInterface {
     }
 
     if ([] !== $contactTypeIds) {
+      $separator = \CRM_Core_DAO::VALUE_SEPARATOR;
       $action->addJoin('ContactType AS ct', 'INNER', NULL,
         CompositeCondition::new('AND',
           Comparison::new('ct.id', 'IN', $contactTypeIds),
           CompositeCondition::new('OR',
-            Comparison::new('ct.name', '=', 'c.contact_type'),
-            Comparison::new('ct.name', '=', 'c.contact_sub_type'),
+            Comparison::new('c.contact_type', '=', 'ct.name'),
+            Comparison::new('c.contact_sub_type', 'LIKE', "CONCAT('%${separator}', ct.name, '${separator}%')")
           )
         )->toArray()
       );

--- a/Civi/Funding/Permission/ContactRelation/Loader/ContactTypeLoader.php
+++ b/Civi/Funding/Permission/ContactRelation/Loader/ContactTypeLoader.php
@@ -46,11 +46,12 @@ final class ContactTypeLoader implements ContactRelationLoaderInterface {
   public function getContacts(string $relationType, array $relationProperties): array {
     $contactTypeId = $relationProperties['contactTypeId'];
     Assert::integerish($contactTypeId);
+    $separator = \CRM_Core_DAO::VALUE_SEPARATOR;
 
     $action = Contact::get(FALSE)
       ->addJoin('ContactType AS ct', 'INNER', NULL, CompositeCondition::new('OR',
         Comparison::new('contact_type', '=', 'ct.name'),
-        Comparison::new('contact_sub_type', '=', 'ct.name'),
+        Comparison::new('contact_sub_type', 'LIKE', "CONCAT('%${separator}', ct.name, '${separator}%')")
       )->toArray())
       ->addWhere('ct.id', '=', $contactTypeId);
 

--- a/Civi/Funding/Permission/ContactRelation/Loader/RelationshipLoader.php
+++ b/Civi/Funding/Permission/ContactRelation/Loader/RelationshipLoader.php
@@ -92,12 +92,13 @@ final class RelationshipLoader implements ContactRelationLoaderInterface {
       );
 
     if ([] !== $contactTypeIds) {
+      $separator = \CRM_Core_DAO::VALUE_SEPARATOR;
       $action->addJoin('ContactType AS ct2', 'INNER', NULL,
         CompositeCondition::new('AND',
           Comparison::new('ct2.id', 'IN', $contactTypeIds),
           CompositeCondition::new('OR',
             Comparison::new('c2.contact_type', '=', 'ct2.name'),
-            Comparison::new('c2.contact_sub_type', '=', 'ct2.name'),
+            Comparison::new('c2.contact_sub_type', 'LIKE', "CONCAT('%${separator}', ct2.name, '${separator}%')")
           )
         )->toArray()
       );

--- a/tests/phpunit/Civi/Funding/Contact/RelationLoader/ContactTypeAndRelationshipTypeLoaderTest.php
+++ b/tests/phpunit/Civi/Funding/Contact/RelationLoader/ContactTypeAndRelationshipTypeLoaderTest.php
@@ -43,6 +43,7 @@ final class ContactTypeAndRelationshipTypeLoaderTest extends AbstractFundingHead
 
   public function testGetRelatedContacts(): void {
     $contactTypeId = ContactTypeFixture::addIndividualFixture('testSubType')['id'];
+    ContactTypeFixture::addIndividualFixture('testSubType2');
     $contact = ContactFixture::addIndividual();
     // Related A to B
     $relatedContact1 = ContactFixture::addIndividual(['last_name' => 'Related 1', 'contact_sub_type' => 'testSubType']);
@@ -51,12 +52,12 @@ final class ContactTypeAndRelationshipTypeLoaderTest extends AbstractFundingHead
     // Wrong relationship type
     $notRelatedContact1 = ContactFixture::addIndividual([
       'last_name' => 'Not Related 1',
-      'contact_sub_type' => 'testSubType',
+      'contact_sub_type' => ['testSubType', 'testSubType2'],
     ]);
     // Inactive relationship
     $inactiveRelationContact = ContactFixture::addIndividual([
       'last_name' => 'Inactive Relationship',
-      'contact_sub_type' => 'testSubType',
+      'contact_sub_type' => ['testSubType', 'testSubType2'],
     ]);
     // Wrong contact type
     $notRelatedContact2 = ContactFixture::addIndividual(['last_name' => 'Not Related 2']);

--- a/tests/phpunit/Civi/Funding/Contact/RelationLoader/SelfByContactTypeLoaderTest.php
+++ b/tests/phpunit/Civi/Funding/Contact/RelationLoader/SelfByContactTypeLoaderTest.php
@@ -42,8 +42,12 @@ final class SelfByContactTypeLoaderTest extends AbstractFundingHeadlessTestCase 
   public function testGetRelatedContacts(): void {
     $contactType = ContactTypeFixture::addFixture(['name' => 'testType']);
     $contactSubType = ContactTypeFixture::addIndividualFixture('testSubType');
+    ContactTypeFixture::addIndividualFixture('testSubType2');
     $contact1 = ContactFixture::addIndividual(['nick_name' => 'Contact 1', 'contact_type' => 'testType']);
-    $contact2 = ContactFixture::addIndividual(['nick_name' => 'Contact 2', 'contact_sub_type' => 'testSubType']);
+    $contact2 = ContactFixture::addIndividual([
+      'nick_name' => 'Contact 2',
+      'contact_sub_type' => ['testSubType', 'testSubType2'],
+    ]);
 
     $relatedContacts1 = $this->relatedContactLoader->getRelatedContacts(
       $contact1['id'],

--- a/tests/phpunit/Civi/Funding/Fixtures/ContactFixture.php
+++ b/tests/phpunit/Civi/Funding/Fixtures/ContactFixture.php
@@ -24,9 +24,8 @@ use Civi\Api4\Contact;
 final class ContactFixture {
 
   /**
-   * @param array<string, scalar> $values
+   * @phpstan-param array<string, mixed> $values
    *
-   * @return array
    * @phpstan-return array<string, scalar|null>&array{id: int}
    *
    * @throws \CRM_Core_Exception

--- a/tests/phpunit/Civi/Funding/Permission/ContactRelation/Loader/ContactTypeLoaderTest.php
+++ b/tests/phpunit/Civi/Funding/Permission/ContactRelation/Loader/ContactTypeLoaderTest.php
@@ -48,8 +48,9 @@ final class ContactTypeLoaderTest extends AbstractFundingHeadlessTestCase {
       ->execute();
 
     $contactType = ContactTypeFixture::addIndividualFixture('testType');
+    ContactTypeFixture::addIndividualFixture('testType2');
     $contact = ContactFixture::addIndividual();
-    $contactWithSubType = ContactFixture::addIndividual(['contact_sub_type' => 'testType']);
+    $contactWithSubType = ContactFixture::addIndividual(['contact_sub_type' => ['testType', 'testType2']]);
 
     static::assertArrayHasSameKeys(
       [$contactWithSubType['id']],

--- a/tests/phpunit/Civi/Funding/Permission/ContactRelation/Loader/RelationshipLoaderTest.php
+++ b/tests/phpunit/Civi/Funding/Permission/ContactRelation/Loader/RelationshipLoaderTest.php
@@ -48,23 +48,24 @@ final class RelationshipLoaderTest extends AbstractFundingHeadlessTestCase {
   public function testGetContacts(): void {
     $contactType1 = ContactTypeFixture::addIndividualFixture('testType1');
     $contactType2 = ContactTypeFixture::addIndividualFixture('testType2');
+    ContactTypeFixture::addIndividualFixture('testType3');
 
     $group1 = GroupFixture::addFixture();
     $group2 = GroupFixture::addFixture();
-    $group2Inactive = GroupFixture::addFixture(['is_active' => FALSE]);
+    $group3Inactive = GroupFixture::addFixture(['is_active' => FALSE]);
 
     $contactInGroup1 = ContactFixture::addIndividual();
     GroupContactFixture::addFixtureWithGroupId($group1['id'], $contactInGroup1['id']);
-    $contactWithSubType1InGroup1 = ContactFixture::addIndividual([
-      'contact_sub_type' => 'testType1',
-      'last_name' => 'With Sub Type1',
+    $contactWithSubType1And3InGroup1 = ContactFixture::addIndividual([
+      'contact_sub_type' => ['testType1', 'testType3'],
+      'last_name' => 'With Sub Type 1 and 3',
     ]);
-    GroupContactFixture::addFixtureWithGroupId($group1['id'], $contactWithSubType1InGroup1['id']);
-    $contactWithSubType2InGroup2 = ContactFixture::addIndividual([
-      'contact_sub_type' => 'testType2',
-      'last_name' => 'With Sub Type2',
+    GroupContactFixture::addFixtureWithGroupId($group1['id'], $contactWithSubType1And3InGroup1['id']);
+    $contactWithSubType2And3InGroup3 = ContactFixture::addIndividual([
+      'contact_sub_type' => ['testType2', 'testType3'],
+      'last_name' => 'With Sub Type 2 and 3',
     ]);
-    GroupContactFixture::addFixtureWithGroupId($group2Inactive['id'], $contactWithSubType2InGroup2['id']);
+    GroupContactFixture::addFixtureWithGroupId($group3Inactive['id'], $contactWithSubType2And3InGroup3['id']);
 
     // Related A to B with sub type1
     $relatedContact1 = ContactFixture::addIndividual(['last_name' => 'Related 1']);
@@ -105,7 +106,7 @@ final class RelationshipLoaderTest extends AbstractFundingHeadlessTestCase {
 
     Relationship::create(FALSE)
       ->setValues([
-        'contact_id_a' => $contactWithSubType1InGroup1['id'],
+        'contact_id_a' => $contactWithSubType1And3InGroup1['id'],
         'contact_id_b' => $relatedContact1['id'],
         'relationship_type_id' => $relationshipType1Id,
       ])->execute();
@@ -120,7 +121,7 @@ final class RelationshipLoaderTest extends AbstractFundingHeadlessTestCase {
     Relationship::create(FALSE)
       ->setValues([
         'contact_id_a' => $relatedContact3['id'],
-        'contact_id_b' => $contactWithSubType2InGroup2['id'],
+        'contact_id_b' => $contactWithSubType2And3InGroup3['id'],
         'relationship_type_id' => $relationshipType1Id,
       ])->execute();
 
@@ -151,11 +152,11 @@ final class RelationshipLoaderTest extends AbstractFundingHeadlessTestCase {
     // Match relationship type.
     static::assertArrayHasSameKeys([
       $relatedContact1['id'],
-      $contactWithSubType1InGroup1['id'],
+      $contactWithSubType1And3InGroup1['id'],
       $contactInGroup1['id'],
       $relatedContact2['id'],
       $relatedContact3['id'],
-      $contactWithSubType2InGroup2['id'],
+      $contactWithSubType2And3InGroup3['id'],
     ], $this->loader->getContacts('Relationship', [
       'relationshipTypeIds' => [$relationshipType1Id],
       'contactTypeIds' => [],
@@ -223,7 +224,7 @@ final class RelationshipLoaderTest extends AbstractFundingHeadlessTestCase {
     static::assertEmpty($this->loader->getContacts('Relationship', [
       'relationshipTypeIds' => [],
       'contactTypeIds' => [],
-      'groupIds' => [$group2Inactive['id']],
+      'groupIds' => [$group3Inactive['id']],
     ]));
 
     // Inactive relationship has no result.


### PR DESCRIPTION
The contact sub type checks now also work if a contact has multiple sub types. Previously they only worked for a single sub type.