### PR TITLE
Make token subscribers usable outside of CiviOffice

### DIFF
--- a/Civi/Funding/EventSubscriber/CiviOffice/ApplicationProcessTokenSubscriber.php
+++ b/Civi/Funding/EventSubscriber/CiviOffice/ApplicationProcessTokenSubscriber.php
@@ -20,7 +20,6 @@ declare(strict_types = 1);
 namespace Civi\Funding\EventSubscriber\CiviOffice;
 
 use Civi\Api4\FundingApplicationProcess;
-use Civi\Core\Event\GenericHookEvent;
 use Civi\Funding\ApplicationProcess\ApplicationProcessManager;
 use Civi\Funding\DocumentRender\CiviOffice\AbstractCiviOfficeTokenSubscriber;
 use Civi\Funding\DocumentRender\CiviOffice\CiviOfficeContextDataHolder;
@@ -58,15 +57,6 @@ class ApplicationProcessTokenSubscriber extends AbstractCiviOfficeTokenSubscribe
     $this->applicationProcessManager = $applicationProcessManager;
   }
 
-  public function onCiviOfficeTokenContext(GenericHookEvent $event): void {
-    parent::onCiviOfficeTokenContext($event);
-    if ($this->getApiEntityName() === $event->entity_type || isset($event->context[$this->getContextKey() . 'Id'])) {
-      /** @var \Civi\Funding\Entity\ApplicationProcessEntity $applicationProcess */
-      $applicationProcess = $event->context[$this->getContextKey()];
-      $event->context['fundingCaseId'] ??= $applicationProcess->getFundingCaseId();
-    }
-  }
-
   protected function getEntity(int $id): ?AbstractEntity {
     return $this->applicationProcessManager->get($id);
   }
@@ -77,6 +67,20 @@ class ApplicationProcessTokenSubscriber extends AbstractCiviOfficeTokenSubscribe
 
   protected function getEntityClass(): string {
     return ApplicationProcessEntity::class;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function getRelatedContextSchemas(): array {
+    return ['fundingCaseId'];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function getRelatedContextValues(AbstractEntity $entity): array {
+    return ['fundingCaseId' => $entity->getFundingCaseId()];
   }
 
 }

--- a/Civi/Funding/EventSubscriber/CiviOffice/DrawdownTokenSubscriber.php
+++ b/Civi/Funding/EventSubscriber/CiviOffice/DrawdownTokenSubscriber.php
@@ -20,7 +20,6 @@ declare(strict_types = 1);
 namespace Civi\Funding\EventSubscriber\CiviOffice;
 
 use Civi\Api4\FundingDrawdown;
-use Civi\Core\Event\GenericHookEvent;
 use Civi\Funding\DocumentRender\CiviOffice\AbstractCiviOfficeTokenSubscriber;
 use Civi\Funding\DocumentRender\CiviOffice\CiviOfficeContextDataHolder;
 use Civi\Funding\Entity\AbstractEntity;
@@ -55,15 +54,6 @@ class DrawdownTokenSubscriber extends AbstractCiviOfficeTokenSubscriber {
     $this->drawdownManager = $drawdownManager;
   }
 
-  public function onCiviOfficeTokenContext(GenericHookEvent $event): void {
-    parent::onCiviOfficeTokenContext($event);
-    if ($this->getApiEntityName() === $event->entity_type || isset($event->context[$this->getContextKey() . 'Id'])) {
-      /** @var \Civi\Funding\Entity\DrawdownEntity $drawdown */
-      $drawdown = $event->context[$this->getContextKey()];
-      $event->context['payoutProcessId'] ??= $drawdown->getPayoutProcessId();
-    }
-  }
-
   protected function getEntity(int $id): ?AbstractEntity {
     return $this->drawdownManager->get($id);
   }
@@ -74,6 +64,20 @@ class DrawdownTokenSubscriber extends AbstractCiviOfficeTokenSubscriber {
 
   protected function getEntityClass(): string {
     return DrawdownEntity::class;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function getRelatedContextSchemas(): array {
+    return ['payoutProcessId'];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function getRelatedContextValues(AbstractEntity $entity): array {
+    return ['payoutProcessId' => $entity->getPayoutProcessId()];
   }
 
 }

--- a/Civi/Funding/EventSubscriber/CiviOffice/FundingCaseTokenSubscriber.php
+++ b/Civi/Funding/EventSubscriber/CiviOffice/FundingCaseTokenSubscriber.php
@@ -20,7 +20,6 @@ declare(strict_types = 1);
 namespace Civi\Funding\EventSubscriber\CiviOffice;
 
 use Civi\Api4\FundingCase;
-use Civi\Core\Event\GenericHookEvent;
 use Civi\Funding\DocumentRender\CiviOffice\AbstractCiviOfficeTokenSubscriber;
 use Civi\Funding\DocumentRender\CiviOffice\CiviOfficeContextDataHolder;
 use Civi\Funding\DocumentRender\Token\TokenNameExtractorInterface;
@@ -60,25 +59,34 @@ class FundingCaseTokenSubscriber extends AbstractCiviOfficeTokenSubscriber {
     $this->fundingCaseManager = $fundingCaseManager;
   }
 
-  public function onCiviOfficeTokenContext(GenericHookEvent $event): void {
-    parent::onCiviOfficeTokenContext($event);
-    if ($this->getApiEntityName() === $event->entity_type || isset($event->context[$this->getContextKey() . 'Id'])) {
-      /** @var \Civi\Funding\Entity\FundingCaseEntity $fundingCase */
-      $fundingCase = $event->context[$this->getContextKey()];
-      $event->context['fundingCaseTypeId'] ??= $fundingCase->getFundingCaseTypeId();
-      // @phpstan-ignore-next-line
-      $event->context['fundingProgramId'] ??= $fundingCase->getFundingProgramId();
-      // @phpstan-ignore-next-line
-      $event->context['contactId'] ??= $fundingCase->getRecipientContactId();
-    }
-  }
-
   protected function getEntity(int $id): ?AbstractEntity {
     return $this->fundingCaseManager->get($id);
   }
 
   protected function getApiEntityName(): string {
     return FundingCase::getEntityName();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function getRelatedContextSchemas(): array {
+    return [
+      'fundingCaseTypeId',
+      'fundingProgramId',
+      'contactId',
+    ];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function getRelatedContextValues(AbstractEntity $entity): array {
+    return [
+      'fundingCaseTypeId' => $entity->getFundingCaseTypeId(),
+      'fundingProgramId' => $entity->getFundingProgramId(),
+      'contactId' => $entity->getRecipientContactId(),
+    ];
   }
 
 }

--- a/Civi/Funding/EventSubscriber/CiviOffice/FundingCaseTypeTokenSubscriber.php
+++ b/Civi/Funding/EventSubscriber/CiviOffice/FundingCaseTypeTokenSubscriber.php
@@ -60,4 +60,18 @@ class FundingCaseTypeTokenSubscriber extends AbstractCiviOfficeTokenSubscriber {
     return FundingCaseType::getEntityName();
   }
 
+  /**
+   * @inheritDoc
+   */
+  protected function getRelatedContextSchemas(): array {
+    return [];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function getRelatedContextValues(AbstractEntity $entity): array {
+    return [];
+  }
+
 }

--- a/Civi/Funding/EventSubscriber/CiviOffice/FundingProgramTokenSubscriber.php
+++ b/Civi/Funding/EventSubscriber/CiviOffice/FundingProgramTokenSubscriber.php
@@ -58,4 +58,18 @@ class FundingProgramTokenSubscriber extends AbstractCiviOfficeTokenSubscriber {
     return FundingProgram::getEntityName();
   }
 
+  /**
+   * @inheritDoc
+   */
+  protected function getRelatedContextSchemas(): array {
+    return [];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function getRelatedContextValues(AbstractEntity $entity): array {
+    return [];
+  }
+
 }

--- a/Civi/Funding/EventSubscriber/CiviOffice/PayoutProcessTokenSubscriber.php
+++ b/Civi/Funding/EventSubscriber/CiviOffice/PayoutProcessTokenSubscriber.php
@@ -79,4 +79,18 @@ class PayoutProcessTokenSubscriber extends AbstractCiviOfficeTokenSubscriber {
     return PayoutProcessEntity::class;
   }
 
+  /**
+   * @inheritDoc
+   */
+  protected function getRelatedContextSchemas(): array {
+    return ['fundingCaseId'];
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function getRelatedContextValues(AbstractEntity $entity): array {
+    return ['fundingCaseId' => $entity->getFundingCaseId()];
+  }
+
 }


### PR DESCRIPTION
It is now possible to use tokens outside of CiviOffice. Just the entity ID needs to be added to the token context. Tokens of related entities will be automatically available, too.

systopia-reference: 25928