### PR TITLE
Do less depend on concrete permissions

### DIFF
--- a/Civi/Funding/Api4/Action/FundingApplicationProcess/GetFieldsAction.php
+++ b/Civi/Funding/Api4/Action/FundingApplicationProcess/GetFieldsAction.php
@@ -62,9 +62,11 @@ final class GetFieldsAction extends DAOGetFieldsAction {
     $fields = parent::getRecords();
     foreach ($fields as &$field) {
       if ('reviewer_calc_contact_id' === $field['name']) {
+        // @todo Make permission depend on funding case type.
         $field['options'] = $this->getReviewerContactOptions('review_calculative');
       }
       elseif ('reviewer_cont_contact_id' === $field['name']) {
+        // @todo Make permission depend on funding case type.
         $field['options'] = $this->getReviewerContactOptions('review_content');
       }
     }

--- a/Civi/Funding/ApplicationProcess/Handler/ApplicationJsonSchemaGetHandler.php
+++ b/Civi/Funding/ApplicationProcess/Handler/ApplicationJsonSchemaGetHandler.php
@@ -49,7 +49,11 @@ final class ApplicationJsonSchemaGetHandler implements ApplicationJsonSchemaGetH
       $command->getApplicationProcessBundle(),
       $command->getApplicationProcessStatusList()
     );
-    $this->jsonSchemaCreateHelper->addCommentProperty($jsonSchema, $command->getApplicationProcessBundle());
+    $this->jsonSchemaCreateHelper->addCommentProperty(
+      $jsonSchema,
+      $command->getApplicationProcessBundle(),
+      $command->getApplicationProcessStatusList()
+    );
     $this->jsonSchemaCreateHelper->addReadOnlyKeywordIfNecessary(
       $jsonSchema,
       $command->getApplicationProcessBundle(),

--- a/Civi/Funding/ApplicationProcess/Helper/ApplicationJsonSchemaCreateHelper.php
+++ b/Civi/Funding/ApplicationProcess/Helper/ApplicationJsonSchemaCreateHelper.php
@@ -24,14 +24,11 @@ use Civi\Funding\Entity\ApplicationProcessEntityBundle;
 use Civi\Funding\Entity\FundingCaseTypeEntity;
 use Civi\Funding\Form\JsonSchema\JsonSchemaComment;
 use Civi\Funding\FundingCaseTypeServiceLocatorContainer;
-use Civi\Funding\Permission\Traits\HasReviewPermissionTrait;
 use Civi\RemoteTools\JsonSchema\JsonSchema;
 use Civi\RemoteTools\JsonSchema\JsonSchemaNull;
 use Civi\RemoteTools\JsonSchema\JsonSchemaString;
 
 class ApplicationJsonSchemaCreateHelper {
-
-  use HasReviewPermissionTrait;
 
   private FundingCaseTypeServiceLocatorContainer $serviceLocatorContainer;
 
@@ -67,14 +64,23 @@ class ApplicationJsonSchemaCreateHelper {
     $this->doAddActionProperty($jsonSchema, $submitActions);
   }
 
+  /**
+   * @phpstan-param array<int, \Civi\Funding\Entity\FullApplicationProcessStatus> $applicationProcessStatusList
+   *   Status of other application processes in same funding case indexed by ID.
+   */
   public function addCommentProperty(
     JsonSchema $jsonSchema,
-    ApplicationProcessEntityBundle $applicationProcessBundle
+    ApplicationProcessEntityBundle $applicationProcessBundle,
+    array $applicationProcessStatusList
   ): void {
     /** @var \Civi\RemoteTools\JsonSchema\JsonSchema $properties */
     $properties = $jsonSchema['properties'];
 
-    if ($this->hasReviewPermission($applicationProcessBundle->getFundingCase()->getPermissions())) {
+    if ($this->getActionsDeterminer($applicationProcessBundle->getFundingCaseType())->isActionAllowed(
+      'add-comment',
+      $applicationProcessBundle,
+      $applicationProcessStatusList
+    )) {
       $properties['comment'] = new JsonSchemaComment();
     }
     else {

--- a/Civi/Funding/ApplicationProcess/Validator/IsReviewCalculativeValidator.php
+++ b/Civi/Funding/ApplicationProcess/Validator/IsReviewCalculativeValidator.php
@@ -81,6 +81,7 @@ final class IsReviewCalculativeValidator implements ConcreteEntityValidatorInter
   }
 
   private function assertPermission(FundingCaseEntity $fundingCase): void {
+    // @todo Make permission depend on funding case type.
     if (!$fundingCase->hasPermission('review_calculative')) {
       throw new UnauthorizedException(E::ts('Permission to change calculative review result is missing.'));
     }

--- a/Civi/Funding/ApplicationProcess/Validator/IsReviewContentValidator.php
+++ b/Civi/Funding/ApplicationProcess/Validator/IsReviewContentValidator.php
@@ -81,6 +81,7 @@ final class IsReviewContentValidator implements ConcreteEntityValidatorInterface
   }
 
   private function assertPermission(FundingCaseEntity $fundingCase): void {
+    // @todo Make permission depend on funding case type.
     if (!$fundingCase->hasPermission('review_content')) {
       throw new UnauthorizedException(E::ts('Permission to change content review result is missing.'));
     }

--- a/Civi/Funding/ApplicationProcess/Validator/ReviewerCalculativeContactValidator.php
+++ b/Civi/Funding/ApplicationProcess/Validator/ReviewerCalculativeContactValidator.php
@@ -97,12 +97,14 @@ final class ReviewerCalculativeContactValidator implements ConcreteEntityValidat
   }
 
   private function assertPermission(FundingCaseEntity $fundingCase): void {
+    // @todo Make permission depend on funding case type.
     if (!$fundingCase->hasPermission('review_calculative')) {
       throw new UnauthorizedException(E::ts('Permission to change calculative reviewer is missing.'));
     }
   }
 
   private function validateContactId(int $contactId, FundingCaseEntity $fundingCase): EntityValidationResult {
+    // @todo Make permission depend on funding case type.
     $possibleReviewers = $this->fundingCaseContactsLoader->getContactsWithPermission(
       $fundingCase,
       'review_calculative',

--- a/Civi/Funding/ApplicationProcess/Validator/ReviewerContentContactValidator.php
+++ b/Civi/Funding/ApplicationProcess/Validator/ReviewerContentContactValidator.php
@@ -97,12 +97,14 @@ final class ReviewerContentContactValidator implements ConcreteEntityValidatorIn
   }
 
   private function assertPermission(FundingCaseEntity $fundingCase): void {
+    // @todo Make permission depend on funding case type.
     if (!$fundingCase->hasPermission('review_content')) {
       throw new UnauthorizedException(E::ts('Permission to change content reviewer is missing.'));
     }
   }
 
   private function validateContactId(int $contactId, FundingCaseEntity $fundingCase): EntityValidationResult {
+    // @todo Make permission depend on funding case type.
     $possibleReviewers = $this->fundingCaseContactsLoader->getContactsWithPermission($fundingCase, 'review_content');
     if (isset($possibleReviewers[$contactId])) {
       return EntityValidationResult::new();

--- a/Civi/Funding/Permission/Traits/HasReviewPermissionTrait.php
+++ b/Civi/Funding/Permission/Traits/HasReviewPermissionTrait.php
@@ -19,6 +19,10 @@ declare(strict_types = 1);
 
 namespace Civi\Funding\Permission\Traits;
 
+/**
+ * Do NOT use this trait if there should be no dependency on concrete
+ * permissions.
+ */
 trait HasReviewPermissionTrait {
 
   /**


### PR DESCRIPTION
`ApplicationJsonSchemaCreateHelper`: Now checks if `add-comment` action is allowed instead of checking permissions.

Other spots are marked with `@todo`.

systopia-reference: 25647