### PR TITLE
Add funding case type to `GetPossibleApplicationProcessStatusEvent`

### DIFF
--- a/Civi/Funding/Event/AbstractGetOptionsEvent.php
+++ b/Civi/Funding/Event/AbstractGetOptionsEvent.php
@@ -71,7 +71,7 @@ abstract class AbstractGetOptionsEvent extends Event {
   }
 
   /**
-   * @phpstan-return array<int, optionT>
+   * @phpstan-return list<optionT>
    */
   public function getOptions(): array {
     return array_values($this->options);

--- a/Civi/Funding/Event/ApplicationProcess/GetPossibleApplicationProcessStatusEvent.php
+++ b/Civi/Funding/Event/ApplicationProcess/GetPossibleApplicationProcessStatusEvent.php
@@ -23,4 +23,15 @@ use Civi\Funding\Event\AbstractGetOptionsEvent;
 
 final class GetPossibleApplicationProcessStatusEvent extends AbstractGetOptionsEvent {
 
+  private ?string $fundingCaseTypeName;
+
+  public function __construct(array $options, ?string $fundingCaseTypeName) {
+    parent::__construct($options);
+    $this->fundingCaseTypeName = $fundingCaseTypeName;
+  }
+
+  public function getFundingCaseTypeName(): ?string {
+    return $this->fundingCaseTypeName;
+  }
+
 }

--- a/ang/crmFunding/application/application.js
+++ b/ang/crmFunding/application/application.js
@@ -51,7 +51,7 @@ fundingModule.controller('fundingApplicationCtrl', [
     };
 
     $scope.statusOptions = {};
-    fundingApplicationProcessService.getStatusOptions(applicationProcess.id)
+    fundingApplicationProcessService.getStatusOptions({id: applicationProcess.id, fundingCaseId: applicationProcess.funding_case_id})
       .then((options) => $scope.statusOptions = options);
 
     $scope.clearingStatusOptions = {};

--- a/ang/crmFunding/application/applicationProcess.factory.js
+++ b/ang/crmFunding/application/applicationProcess.factory.js
@@ -27,13 +27,13 @@ fundingModule.factory('fundingApplicationProcessService', ['crmApi4', function(c
   }
 
   /**
-   * @param {integer} id
+   * @param {object} values
    * @param {string} field
    *
    * @returns {Promise<object[]>}
    *   Options with option name as index.
    */
-  function getOptions(id, field) {
+  function getOptions(values, field) {
     return crmApi4('FundingApplicationProcess', 'getFields', {
       loadOptions: [
         'id',
@@ -44,7 +44,7 @@ fundingModule.factory('fundingApplicationProcessService', ['crmApi4', function(c
         'color',
         'icon',
       ],
-      values: {id},
+      values: values,
       where: [['name', '=', field]],
       select: ['options']
     }).then(function (result) {
@@ -109,12 +109,12 @@ fundingModule.factory('fundingApplicationProcessService', ['crmApi4', function(c
     applyActionMultiple: (ids, action) => crmApi4('FundingApplicationProcess', 'applyActionMultiple', {ids, action}),
 
     /**
-     * @param {integer} id
+     * @param {object} values
      *
      * @returns {Promise<object[]>}
      *   Options with option name as index.
      */
-    getStatusOptions: (id) => getOptions(id, 'status'),
+    getStatusOptions: (values) => getOptions(values, 'status'),
     getOptionLabels: (id, field) => getOptionLabels(id, field),
   };
 }]);

--- a/ang/crmFunding/clearing/clearing.js
+++ b/ang/crmFunding/clearing/clearing.js
@@ -51,7 +51,7 @@ fundingModule.controller('fundingClearingCtrl', [
     };
 
     $scope.applicationStatusOptions = {};
-    fundingApplicationProcessService.getStatusOptions(clearingProcess.application_process_id)
+    fundingApplicationProcessService.getStatusOptions({id: clearingProcess.application_process_id})
       .then((options) => $scope.applicationStatusOptions = options);
 
     $scope.clearingStatusOptions = {};

--- a/tests/phpunit/Civi/Api4/FundingApplicationProcessTest.php
+++ b/tests/phpunit/Civi/Api4/FundingApplicationProcessTest.php
@@ -159,13 +159,18 @@ final class FundingApplicationProcessTest extends AbstractFundingHeadlessTestCas
     static::assertTrue($result['reviewer_cont_contact_id']['options']);
 
     // Load options with unknown application process ID.
-    $result = FundingApplicationProcess::getFields()
-      ->setLoadOptions(TRUE)
-      ->addValue('id', $applicationProcess->getId() + 1)
-      ->execute()
-      ->indexBy('name');
-    static::assertTrue($result['reviewer_calc_contact_id']['options']);
-    static::assertTrue($result['reviewer_cont_contact_id']['options']);
+    $e = NULL;
+    try {
+      FundingApplicationProcess::getFields()
+        ->setLoadOptions(TRUE)
+        ->addValue('id', $applicationProcess->getId() + 1)
+        ->execute()
+        ->indexBy('name');
+    }
+    catch (\CRM_Core_Exception $e) {
+      // @ignoreException
+    }
+    static::assertNotNull($e);
 
     // Load options with known application process ID.
     $result = FundingApplicationProcess::getFields()
@@ -180,13 +185,18 @@ final class FundingApplicationProcessTest extends AbstractFundingHeadlessTestCas
 
     // Load options without application process permission.
     RequestTestUtil::mockInternalRequest($contactNotPermitted['id']);
-    $result = FundingApplicationProcess::getFields()
-      ->setLoadOptions(TRUE)
-      ->addValue('id', $applicationProcess->getId())
-      ->execute()
-      ->indexBy('name');
-    static::assertTrue($result['reviewer_calc_contact_id']['options']);
-    static::assertTrue($result['reviewer_cont_contact_id']['options']);
+    $e = NULL;
+    try {
+      FundingApplicationProcess::getFields()
+        ->setLoadOptions(TRUE)
+        ->addValue('id', $applicationProcess->getId())
+        ->execute()
+        ->indexBy('name');
+    }
+    catch (\CRM_Core_Exception $e) {
+      // @ignoreException
+    }
+    static::assertNotNull($e);
   }
 
   public function testGetFormData(): void {


### PR DESCRIPTION
This allows funding case types to explicitly set the possible application process status.

systopia-reference: 27162