### PR TITLE
Migrate initial funding case permissions on upgrade

### DIFF
--- a/Civi/Funding/Upgrade/Upgrader0008.php
+++ b/Civi/Funding/Upgrade/Upgrader0008.php
@@ -20,6 +20,7 @@ declare(strict_types = 1);
 namespace Civi\Funding\Upgrade;
 
 use Civi\Api4\FundingCaseContactRelation;
+use Civi\Api4\FundingNewCasePermissions;
 use Civi\Api4\FundingProgramContactRelation;
 use Civi\Funding\Permission\ContactRelation\Types\ContactTypeAndGroup;
 use Civi\RemoteTools\Api4\Api4Interface;
@@ -39,6 +40,9 @@ final class Upgrader0008 {
   public function execute(\Log $log): void {
     $log->info('Migrate funding program permissions');
     $this->migrateRelations(FundingProgramContactRelation::getEntityName());
+
+    $log->info('Migrate initial funding case permissions');
+    $this->migrateRelations(FundingNewCasePermissions::getEntityName());
 
     $log->info('Migrate funding case permissions');
     $this->migrateRelations(FundingCaseContactRelation::getEntityName());

--- a/tests/phpunit/Civi/Funding/Fixtures/FundingNewCasePermissionsFixture.php
+++ b/tests/phpunit/Civi/Funding/Fixtures/FundingNewCasePermissionsFixture.php
@@ -32,11 +32,23 @@ final class FundingNewCasePermissionsFixture {
    * @throws \CRM_Core_Exception
    */
   public static function addCreationContact(int $fundingProgramId, array $permissions): array {
+    return self::addFixture($fundingProgramId, CreationContact::NAME, [], $permissions);
+  }
+
+  /**
+   * @phpstan-param array<mixed> $properties
+   * @phpstan-param list<string> $permissions
+   *
+   * @phpstan-return array<string, scalar|null>&array{id: int}
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function addFixture(int $fundingProgramId, string $type, array $properties, array $permissions): array {
     return FundingNewCasePermissions::create(FALSE)
       ->setValues([
         'funding_program_id' => $fundingProgramId,
-        'type' => CreationContact::NAME,
-        'properties' => [],
+        'type' => $type,
+        'properties' => $properties,
         'permissions' => $permissions,
       ])->execute()->first();
   }

--- a/tests/phpunit/Civi/Funding/Upgrade/Upgrader0008Test.php
+++ b/tests/phpunit/Civi/Funding/Upgrade/Upgrader0008Test.php
@@ -20,12 +20,14 @@ declare(strict_types = 1);
 namespace tests\phpunit\Civi\Funding\Upgrade;
 
 use Civi\Api4\FundingCaseContactRelation;
+use Civi\Api4\FundingNewCasePermissions;
 use Civi\Api4\FundingProgramContactRelation;
 use Civi\Funding\AbstractFundingHeadlessTestCase;
 use Civi\Funding\Fixtures\ContactFixture;
 use Civi\Funding\Fixtures\FundingCaseContactRelationFixture;
 use Civi\Funding\Fixtures\FundingCaseFixture;
 use Civi\Funding\Fixtures\FundingCaseTypeFixture;
+use Civi\Funding\Fixtures\FundingNewCasePermissionsFixture;
 use Civi\Funding\Fixtures\FundingProgramContactRelationFixture;
 use Civi\Funding\Fixtures\FundingProgramFixture;
 use Civi\Funding\Upgrade\Upgrader0008;
@@ -45,6 +47,10 @@ final class Upgrader0008Test extends AbstractFundingHeadlessTestCase {
     FundingProgramContactRelationFixture::addFixture($fundingProgram->getId(), 'ContactType', [
       'contactTypeId' => 2,
     ], ['program_permission']);
+
+    FundingNewCasePermissionsFixture::addFixture($fundingProgram->getId(), 'ContactType', [
+      'contactTypeId' => 3,
+    ], ['new_case_permission']);
 
     $fundingCaseType = FundingCaseTypeFixture::addFixture();
     $contact = ContactFixture::addIndividual();
@@ -74,6 +80,16 @@ final class Upgrader0008Test extends AbstractFundingHeadlessTestCase {
         'groupIds' => [],
       ],
     ], FundingProgramContactRelation::get(FALSE)->execute()->single());
+
+    static::assertArraySubset([
+      'type' => 'ContactTypeAndGroup',
+      'funding_program_id' => $fundingProgram->getId(),
+      'permissions' => ['new_case_permission'],
+      'properties' => [
+        'contactTypeIds' => [3],
+        'groupIds' => [],
+      ],
+    ], FundingNewCasePermissions::get(FALSE)->execute()->single());
 
     static::assertArraySubset([
       'type' => 'ContactTypeAndGroup',


### PR DESCRIPTION
This was missing in #367.