### PR TITLE
Fix AVK1 and IJB Sachbericht JSON schema

### DIFF
--- a/Civi/Funding/IJB/Report/JsonSchema/IJBSachberichtJsonSchema.php
+++ b/Civi/Funding/IJB/Report/JsonSchema/IJBSachberichtJsonSchema.php
@@ -46,7 +46,7 @@ final class IJBSachberichtJsonSchema extends JsonSchemaObject {
           'in Präsenz mit digitalen Anteilen' => 'digitaleAnteile',
         ]),
       ], TRUE),
-      'aenderungen' => new JsonSchemaString(),
+      'aenderungen' => new JsonSchemaString([], TRUE),
       'sprache' => new JsonSchemaString([
         'oneOf' => JsonSchemaUtil::buildTitledOneOf2([
           '' => NULL,

--- a/Civi/Funding/SonstigeAktivitaet/Report/JsonSchema/AVK1SachberichtJsonSchema.php
+++ b/Civi/Funding/SonstigeAktivitaet/Report/JsonSchema/AVK1SachberichtJsonSchema.php
@@ -36,7 +36,7 @@ final class AVK1SachberichtJsonSchema extends JsonSchemaObject {
           'mit folgenden wesentlichen Änderungen (kurze Begründung für die Änderung):' => 'geaendert',
         ]),
       ], TRUE),
-      'aenderungen' => new JsonSchemaString(),
+      'aenderungen' => new JsonSchemaString([], TRUE),
       'thematischeSchwerpunkte' => new JsonSchemaString(),
       'methoden' => new JsonSchemaString(),
       'zielgruppe' => new JsonSchemaString(),

--- a/tests/phpunit/Civi/Funding/SammelantragKurs/Report/KursReportFormFactoryTest.php
+++ b/tests/phpunit/Civi/Funding/SammelantragKurs/Report/KursReportFormFactoryTest.php
@@ -72,10 +72,6 @@ final class KursReportFormFactoryTest extends TestCase {
       '_action' => 'save',
       'reportData' => (object) [
         'grunddaten' => $grunddaten,
-        'sachbericht' => (object) [
-          'aenderungen' => '',
-          'thematischeSchwerpunkte' => '',
-        ],
         'dokumente' => (object) [
           'dateien' => [],
         ],

--- a/tests/phpunit/Civi/Funding/SonstigeAktivitaet/Report/AVK1ReportFormFactoryTest.php
+++ b/tests/phpunit/Civi/Funding/SonstigeAktivitaet/Report/AVK1ReportFormFactoryTest.php
@@ -66,7 +66,7 @@ final class AVK1ReportFormFactoryTest extends TestCase {
       'reportData' => (object) [
         'grunddaten' => $grunddaten,
         'sachbericht' => (object) [
-          'aenderungen' => '',
+          'aenderungen' => NULL,
           'thematischeSchwerpunkte' => '',
         ],
         'dokumente' => (object) [


### PR DESCRIPTION
_When_ `aenderungen` was empty and `durchgefuehrt` was set to `'geplant'` validation of `aenderungen` failed because it wasn't allowed to be `NULL`.

systopia-reference: 27474