### PR TITLE
Regard funding case access permissions in aggregate row of SearchKit

### DIFF
--- a/Civi/Api4/FundingApplicationProcess.php
+++ b/Civi/Api4/FundingApplicationProcess.php
@@ -76,7 +76,7 @@ class FundingApplicationProcess extends Generic\DAOEntity {
    * @return \Civi\Funding\Api4\Action\FundingApplicationProcess\GetAction
    */
   public static function get($checkPermissions = TRUE) {
-    return \Civi::service(GetAction::class)->setCheckPermissions($checkPermissions);
+    return (new GetAction())->setCheckPermissions($checkPermissions);
   }
 
   public static function getFields($checkPermissions = TRUE) {

--- a/Civi/Api4/FundingCase.php
+++ b/Civi/Api4/FundingCase.php
@@ -58,7 +58,7 @@ final class FundingCase extends Generic\DAOEntity {
    * @return \Civi\Funding\Api4\Action\FundingCase\GetAction
    */
   public static function get($checkPermissions = TRUE) {
-    return \Civi::service(GetAction::class)->setCheckPermissions($checkPermissions);
+    return (new GetAction())->setCheckPermissions($checkPermissions);
   }
 
   /**

--- a/Civi/Api4/FundingClearingCostItem.php
+++ b/Civi/Api4/FundingClearingCostItem.php
@@ -19,7 +19,7 @@ final class FundingClearingCostItem extends Generic\DAOEntity {
   use AccessROPermissionsTrait;
 
   public static function get($checkPermissions = TRUE) {
-    return \Civi::service(GetAction::class)->setCheckPermissions($checkPermissions);
+    return (new GetAction())->setCheckPermissions($checkPermissions);
   }
 
   public static function getFields($checkPermissions = TRUE) {

--- a/Civi/Api4/FundingClearingProcess.php
+++ b/Civi/Api4/FundingClearingProcess.php
@@ -26,7 +26,7 @@ final class FundingClearingProcess extends Generic\DAOEntity {
   }
 
   public static function get($checkPermissions = TRUE) {
-    return \Civi::service(GetAction::class)->setCheckPermissions($checkPermissions);
+    return (new GetAction())->setCheckPermissions($checkPermissions);
   }
 
   public static function getFields($checkPermissions = TRUE) {

--- a/Civi/Api4/FundingClearingResourcesItem.php
+++ b/Civi/Api4/FundingClearingResourcesItem.php
@@ -19,7 +19,7 @@ final class FundingClearingResourcesItem extends Generic\DAOEntity {
   use AccessROPermissionsTrait;
 
   public static function get($checkPermissions = TRUE) {
-    return \Civi::service(GetAction::class)->setCheckPermissions($checkPermissions);
+    return (new GetAction())->setCheckPermissions($checkPermissions);
   }
 
   public static function getFields($checkPermissions = TRUE) {

--- a/Civi/Api4/FundingDrawdown.php
+++ b/Civi/Api4/FundingDrawdown.php
@@ -35,7 +35,7 @@ final class FundingDrawdown extends Generic\DAOEntity {
   }
 
   public static function get($checkPermissions = TRUE) {
-    return \Civi::service(GetAction::class)->setCheckPermissions($checkPermissions);
+    return (new GetAction())->setCheckPermissions($checkPermissions);
   }
 
   public static function getFields($checkPermissions = TRUE) {

--- a/Civi/Api4/FundingPayoutProcess.php
+++ b/Civi/Api4/FundingPayoutProcess.php
@@ -19,7 +19,7 @@ class FundingPayoutProcess extends Generic\DAOEntity {
   use AccessPermissionsTrait;
 
   public static function get($checkPermissions = TRUE) {
-    return \Civi::service(GetAction::class)->setCheckPermissions($checkPermissions);
+    return (new GetAction())->setCheckPermissions($checkPermissions);
   }
 
   public static function getFields($checkPermissions = TRUE) {

--- a/Civi/Funding/Api4/Action/FundingApplicationProcess/GetAction.php
+++ b/Civi/Funding/Api4/Action/FundingApplicationProcess/GetAction.php
@@ -33,9 +33,9 @@ use Webmozart\Assert\Assert;
 final class GetAction extends AbstractReferencingDAOGetAction {
 
   public function __construct(
-    Api4Interface $api4,
-    FundingCaseManager $fundingCaseManager,
-    RequestContextInterface $requestContext
+    ?Api4Interface $api4 = NULL,
+    ?FundingCaseManager $fundingCaseManager = NULL,
+    ?RequestContextInterface $requestContext = NULL
   ) {
     parent::__construct(
       FundingApplicationProcess::getEntityName(),
@@ -68,7 +68,7 @@ final class GetAction extends AbstractReferencingDAOGetAction {
     if ([] !== $clearingProcessFields) {
       /** @phpstan-var array<string, mixed> $record */
       foreach ($result as &$record) {
-        $clearingProcessAmounts = $this->_api4->execute(FundingClearingProcess::getEntityName(), 'get', [
+        $clearingProcessAmounts = $this->getApi4()->execute(FundingClearingProcess::getEntityName(), 'get', [
           'select' => array_map(fn (string $field) => 'SUM(' . $field . ') AS SUM_' . $field, $clearingProcessFields),
           'where' => [
             ['application_process_id', '=', $record['id']],
@@ -91,7 +91,7 @@ final class GetAction extends AbstractReferencingDAOGetAction {
       return FALSE;
     }
 
-    if (0 !== $this->_api4->countEntities(
+    if (0 !== $this->getApi4()->countEntities(
         FundingClearingProcess::getEntityName(),
         Comparison::new(
           'application_process_id',
@@ -102,7 +102,7 @@ final class GetAction extends AbstractReferencingDAOGetAction {
       return TRUE;
     }
 
-    $fundingCase = $this->_fundingCaseManager->get($record['funding_case_id']);
+    $fundingCase = $this->getFundingCaseManager()->get($record['funding_case_id']);
     Assert::notNull($fundingCase);
 
     return $fundingCase->hasPermission(ClearingProcessPermissions::CLEARING_MODIFY) || $fundingCase->hasPermission(

--- a/Civi/Funding/Api4/Action/FundingClearingCostItem/GetAction.php
+++ b/Civi/Funding/Api4/Action/FundingClearingCostItem/GetAction.php
@@ -27,9 +27,9 @@ use Civi\RemoteTools\RequestContext\RequestContextInterface;
 final class GetAction extends \Civi\Funding\Api4\Action\Generic\ClearingItem\GetAction {
 
   public function __construct(
-    Api4Interface $api4,
-    FundingCaseManager $fundingCaseManager,
-    RequestContextInterface $requestContext
+    ?Api4Interface $api4 = NULL,
+    ?FundingCaseManager $fundingCaseManager = NULL,
+    ?RequestContextInterface $requestContext = NULL
   ) {
     parent::__construct(
       FundingClearingCostItem::getEntityName(),

--- a/Civi/Funding/Api4/Action/FundingClearingProcess/GetAction.php
+++ b/Civi/Funding/Api4/Action/FundingClearingProcess/GetAction.php
@@ -28,9 +28,9 @@ use Civi\RemoteTools\RequestContext\RequestContextInterface;
 final class GetAction extends AbstractReferencingDAOGetAction {
 
   public function __construct(
-    Api4Interface $api4,
-    FundingCaseManager $fundingCaseManager,
-    RequestContextInterface $requestContext
+    ?Api4Interface $api4 = NULL,
+    ?FundingCaseManager $fundingCaseManager = NULL,
+    ?RequestContextInterface $requestContext = NULL
   ) {
     parent::__construct(
       FundingClearingProcess::getEntityName(),

--- a/Civi/Funding/Api4/Action/FundingClearingResourcesItem/GetAction.php
+++ b/Civi/Funding/Api4/Action/FundingClearingResourcesItem/GetAction.php
@@ -27,9 +27,9 @@ use Civi\RemoteTools\RequestContext\RequestContextInterface;
 final class GetAction extends \Civi\Funding\Api4\Action\Generic\ClearingItem\GetAction {
 
   public function __construct(
-    Api4Interface $api4,
-    FundingCaseManager $fundingCaseManager,
-    RequestContextInterface $requestContext
+    ?Api4Interface $api4 = NULL,
+    ?FundingCaseManager $fundingCaseManager = NULL,
+    ?RequestContextInterface $requestContext = NULL
   ) {
     parent::__construct(
       FundingClearingResourcesItem::getEntityName(),

--- a/Civi/Funding/Api4/Action/FundingDrawdown/GetAction.php
+++ b/Civi/Funding/Api4/Action/FundingDrawdown/GetAction.php
@@ -41,9 +41,9 @@ final class GetAction extends AbstractReferencingDAOGetAction {
   private array $fundingCases = [];
 
   public function __construct(
-    Api4Interface $api4,
-    FundingCaseManager $fundingCaseManager,
-    RequestContextInterface $requestContext
+    ?Api4Interface $api4 = NULL,
+    ?FundingCaseManager $fundingCaseManager = NULL,
+    ?RequestContextInterface $requestContext = NULL
   ) {
     parent::__construct(
       FundingDrawdown::getEntityName(),
@@ -85,7 +85,7 @@ final class GetAction extends AbstractReferencingDAOGetAction {
       $action->addWhere('pp.id', '=', $payoutProcessId);
     }
 
-    $this->_api4->executeAction($action);
+    $this->getApi4()->executeAction($action);
   }
 
   protected function handleRecord(array &$record): bool {
@@ -111,7 +111,7 @@ final class GetAction extends AbstractReferencingDAOGetAction {
    */
   private function getFundingCase(int $id): FundingCaseEntity {
     if (!isset($this->fundingCases[$id])) {
-      $fundingCase = $this->_fundingCaseManager->get($id);
+      $fundingCase = $this->getFundingCaseManager()->get($id);
       Assert::notNull($fundingCase, sprintf('Funding case with ID "%d" not found', $id));
       $this->fundingCases[$id] = $fundingCase;
     }

--- a/Civi/Funding/Api4/Action/FundingPayoutProcess/GetAction.php
+++ b/Civi/Funding/Api4/Action/FundingPayoutProcess/GetAction.php
@@ -28,9 +28,9 @@ use Civi\RemoteTools\RequestContext\RequestContextInterface;
 final class GetAction extends AbstractReferencingDAOGetAction {
 
   public function __construct(
-    Api4Interface $api4,
-    FundingCaseManager $fundingCaseManager,
-    RequestContextInterface $requestContext
+    ?Api4Interface $api4 = NULL,
+    ?FundingCaseManager $fundingCaseManager = NULL,
+    ?RequestContextInterface $requestContext = NULL
   ) {
     parent::__construct(FundingPayoutProcess::getEntityName(), $api4, $fundingCaseManager, $requestContext);
   }

--- a/Civi/Funding/Api4/Action/Generic/ClearingItem/GetAction.php
+++ b/Civi/Funding/Api4/Action/Generic/ClearingItem/GetAction.php
@@ -42,9 +42,9 @@ class GetAction extends AbstractReferencingDAOGetAction {
 
   public function __construct(
     string $entityName,
-    Api4Interface $api4,
-    FundingCaseManager $fundingCaseManager,
-    RequestContextInterface $requestContext
+    ?Api4Interface $api4 = NULL,
+    ?FundingCaseManager $fundingCaseManager = NULL,
+    ?RequestContextInterface $requestContext = NULL
   ) {
     parent::__construct(
       $entityName,
@@ -88,7 +88,7 @@ class GetAction extends AbstractReferencingDAOGetAction {
       $action->addWhere('cp.id', '=', $clearingProcessId);
     }
 
-    $this->_api4->executeAction($action);
+    $this->getApi4()->executeAction($action);
   }
 
   protected function handleRecord(array &$record): bool {
@@ -112,7 +112,7 @@ class GetAction extends AbstractReferencingDAOGetAction {
    */
   private function getFundingCase(int $id): FundingCaseEntity {
     if (!isset($this->fundingCases[$id])) {
-      $fundingCase = $this->_fundingCaseManager->get($id);
+      $fundingCase = $this->getFundingCaseManager()->get($id);
       Assert::notNull($fundingCase, sprintf('Funding case with ID "%d" not found', $id));
       $this->fundingCases[$id] = $fundingCase;
     }

--- a/services/application-process.php
+++ b/services/application-process.php
@@ -22,7 +22,6 @@ declare(strict_types = 1);
 
 use Civi\Funding\Api4\Action\FundingApplicationProcess\CreateAction;
 use Civi\Funding\Api4\Action\FundingApplicationProcess\DeleteAction;
-use Civi\Funding\Api4\Action\FundingApplicationProcess\GetAction;
 use Civi\Funding\Api4\Action\FundingApplicationProcess\GetFieldsAction;
 use Civi\Funding\Api4\Action\FundingApplicationProcess\GetFormDataAction;
 use Civi\Funding\Api4\Action\FundingApplicationProcess\GetJsonSchemaAction;
@@ -193,9 +192,6 @@ $container->autowire(CreateAction::class)
 $container->autowire(DeleteAction::class)
   ->setPublic(TRUE)
   ->setShared(TRUE);
-$container->autowire(GetAction::class)
-  ->setPublic(TRUE)
-  ->setShared(FALSE);
 $container->autowire(GetFieldsAction::class)
   ->setPublic(TRUE)
   ->setShared(FALSE);

--- a/services/clearing-process.php
+++ b/services/clearing-process.php
@@ -101,14 +101,6 @@ $container->autowire(\Civi\Funding\Api4\Action\FundingClearingProcess\GetFieldsA
   ->setPublic(TRUE)
   ->setShared(FALSE);
 
-$container->autowire(\Civi\Funding\Api4\Action\FundingClearingCostItem\GetAction::class)
-  ->setPublic(TRUE)
-  ->setShared(FALSE);
-
-$container->autowire(\Civi\Funding\Api4\Action\FundingClearingResourcesItem\GetAction::class)
-  ->setPublic(TRUE)
-  ->setShared(FALSE);
-
 ServiceRegistrator::autowireAllImplementing(
   $container,
   __DIR__ . '/../Civi/Funding/ClearingProcess/Api4/ActionHandler',

--- a/services/funding-case.php
+++ b/services/funding-case.php
@@ -77,10 +77,22 @@ $container->addCompilerPass(new PossibleRecipientsForChangeLoaderPass());
 $container->addCompilerPass(new FundingCaseRecipientContactSetHandlerPass());
 $container->addCompilerPass(new FundingCaseNotificationContactsSetHandlerPass());
 
-$container->autowire(FundingCaseManager::class);
+$container->autowire(FundingCaseManager::class)
+  // phpcs:disable Squiz.PHP.CommentedOutCode.Found
+  // Accessed in \Civi\Funding\Api4\Action\FundingCase\AbstractReferencingDAOGetAction.
+  // phpcs:enable
+  ->setPublic(TRUE);
 $container->autowire(FundingCasePermissionsInitializer::class);
-$container->autowire(FundingCasePermissionsCacheManager::class);
-$container->autowire(TransferContractRouter::class);
+$container->autowire(FundingCasePermissionsCacheManager::class)
+  // phpcs:disable Squiz.PHP.CommentedOutCode.Found
+  // Used in class \Civi\Funding\Api4\Action\FundingCase\GetAction.
+  // phpcs:enable
+  ->setPublic(TRUE);
+$container->autowire(TransferContractRouter::class)
+  // phpcs:disable Squiz.PHP.CommentedOutCode.Found
+  // Used in class \Civi\Funding\Api4\Action\FundingCase\GetAction.
+  // phpcs:enable
+  ->setPublic(TRUE);
 $container->autowire(FundingCaseIdentifierGeneratorInterface::class, FundingCaseIdentifierGenerator::class);
 $container->autowire(FallbackPossibleRecipientsForChangeLoader::class);
 

--- a/services/payout-process.php
+++ b/services/payout-process.php
@@ -45,18 +45,6 @@ $container->autowire(DrawdownTokenResolver::class);
 
 ServiceRegistrator::autowireAllImplementing(
   $container,
-  __DIR__ . '/../Civi/Funding/Api4/Action/FundingPayoutProcess',
-  'Civi\\Funding\\Api4\\Action\\FundingPayoutProcess',
-  AbstractAction::class,
-  [],
-  [
-    'public' => TRUE,
-    'shared' => FALSE,
-  ]
-);
-
-ServiceRegistrator::autowireAllImplementing(
-  $container,
   __DIR__ . '/../Civi/Funding/Api4/Action/FundingDrawdown',
   'Civi\\Funding\\Api4\\Action\\FundingDrawdown',
   AbstractAction::class,

--- a/services/remote-tools.php
+++ b/services/remote-tools.php
@@ -39,7 +39,11 @@ $container->setAlias(LoggerInterface::class, 'psr_log');
 $container->register(TransactionFactory::class);
 
 $container->autowire(OptionsLoaderInterface::class, OptionsLoader::class);
-$container->autowire(PossiblePermissionsLoaderInterface::class, PossiblePermissionsLoader::class);
+$container->autowire(PossiblePermissionsLoaderInterface::class, PossiblePermissionsLoader::class)
+  // phpcs:disable Squiz.PHP.CommentedOutCode.Found
+  // Used in class \Civi\Funding\Api4\Action\FundingCase\GetAction.
+  // phpcs:enable
+  ->setPublic(TRUE);
 
 $container->autowire(ApiAuthorizeInitRequestSubscriber::class)
   ->addTag('kernel.event_subscriber');


### PR DESCRIPTION
Previously all funding cases or funding case related entities have been used to calculate the aggregations in SearchKit regardless of the access permission.

Additionally the services for the related actions are replaced with simple object creation #376.

systopia-reference: 27672