### PR TITLE
IJB: Allow `andereSprache` in Sachbericht to be `NULL` if value is not required

### DIFF
--- a/Civi/Funding/IJB/Report/JsonSchema/IJBSachberichtJsonSchema.php
+++ b/Civi/Funding/IJB/Report/JsonSchema/IJBSachberichtJsonSchema.php
@@ -55,7 +55,7 @@ final class IJBSachberichtJsonSchema extends JsonSchemaObject {
           'auf:' => 'andere',
         ]),
       ], TRUE),
-      'andereSprache' => new JsonSchemaString(['maxLength' => 50]),
+      'andereSprache' => new JsonSchemaString(['maxLength' => 50], TRUE),
 
       // Abschnitt 1: Sprachliche Verständigung
       'verstaendigungBewertung' => new JsonSchemaString([


### PR DESCRIPTION
systopia-reference: 27903