### PR TITLE
Add missing input_type for template upload fields

### DIFF
--- a/ang/afformFundingCaseTypeTemplates.aff.html
+++ b/ang/afformFundingCaseTypeTemplates.aff.html
@@ -1,9 +1,9 @@
 <af-form ctrl="afform">
   <af-entity type="FundingCaseType" name="fundingCaseType" label="fundingCaseType" actions="{create: false, update: true}" security="RBAC" url-autofill="1" />
   <fieldset af-fieldset="fundingCaseType" class="af-container">
-    <af-field name="transfer_contract_template_file_id" />
-    <af-field name="payment_instruction_template_file_id" />
-    <af-field name="payback_claim_template_file_id" />
+    <af-field name="transfer_contract_template_file_id" defn="{input_type: 'File'}" />
+    <af-field name="payment_instruction_template_file_id" defn="{input_type: 'File'}" />
+    <af-field name="payback_claim_template_file_id" defn="{input_type: 'File'}" />
   </fieldset>
   <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Submit</button>
 </af-form>


### PR DESCRIPTION
The fields are printed as display_only in 5.81.x, but this input type upload buttons are visible again.

Is this a regression in Civi? A old deprecated thing which was removed in 5.81.x?