### PR TITLE
Load funding case from database for update event

### DIFF
--- a/Civi/Funding/FundingCase/FundingCaseManager.php
+++ b/Civi/Funding/FundingCase/FundingCaseManager.php
@@ -229,8 +229,11 @@ class FundingCaseManager {
     return $fundingCase ?? $this->create($contactId, $values);
   }
 
+  /**
+   * @throws \CRM_Core_Exception
+   */
   public function update(FundingCaseEntity $fundingCase): void {
-    $previousFundingCase = $this->get($fundingCase->getId());
+    $previousFundingCase = $this->getWithoutCache($fundingCase->getId());
     Assert::notNull($previousFundingCase, 'Funding case could not be loaded');
     if ($fundingCase->getModificationDate() == $previousFundingCase->getModificationDate()) {
       $fundingCase->setModificationDate(new \DateTime(date('Y-m-d H:i:s')));
@@ -313,6 +316,14 @@ class FundingCaseManager {
     $fundingCases = $this->getFundingCasesFromApiResult($result);
 
     return $fundingCases[0] ?? NULL;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  private function getWithoutCache(int $id): ?FundingCaseEntity {
+    // @phpstan-ignore argument.type
+    return FundingCaseEntity::fromArrayOrNull($this->api4->getEntity(FundingCase::getEntityName(), $id));
   }
 
 }

--- a/tests/phpunit/Civi/Funding/FundingCase/FundingCaseManagerTest.php
+++ b/tests/phpunit/Civi/Funding/FundingCase/FundingCaseManagerTest.php
@@ -409,7 +409,8 @@ final class FundingCaseManagerTest extends AbstractFundingHeadlessTestCase {
     \CRM_Core_Session::singleton()->set('userID', $contact['id']);
     FundingCaseContactRelationFixture::addContact($contact['id'], $fundingCase->getId(), ['test_permission']);
 
-    $updatedFundingCase = FundingCaseEntity::fromArray($fundingCase->toArray());
+    $updatedFundingCase = $this->fundingCaseManager->get($fundingCase->getId());
+    static::assertNotNull($updatedFundingCase);
     $updatedFundingCase->setStatus('updated');
 
     // Reload to have permission fields required for the event object comparison.


### PR DESCRIPTION
Previously the funding case was fetched from cache so previous and current funding case in `FundingCasePreUpdateEvent` and `FundingCaseUpdatedEvent` where the same object.