### PR TITLE
Allow to reset review flag without specific review permission

### DIFF
--- a/Civi/Funding/Api4/Action/Traits/ActionRecordValidationTrait.php
+++ b/Civi/Funding/Api4/Action/Traits/ActionRecordValidationTrait.php
@@ -122,7 +122,7 @@ trait ActionRecordValidationTrait {
     $entityClass = $this->_getEntityClass();
     $entity = $entityClass::fromArray($record);
 
-    return $this->_entityValidator->validateNew($entity);
+    return $this->_entityValidator->validateNew($entity, $this->getCheckPermissions());
   }
 
   /**
@@ -139,7 +139,7 @@ trait ActionRecordValidationTrait {
     $new = $entityClass::fromArray($record + $currentRecord);
     $current = $entityClass::fromArray($currentRecord);
 
-    return $this->_entityValidator->validate($new, $current);
+    return $this->_entityValidator->validate($new, $current, $this->getCheckPermissions());
   }
 
   /**

--- a/Civi/Funding/ApplicationProcess/Validator/IsReviewCalculativeValidator.php
+++ b/Civi/Funding/ApplicationProcess/Validator/IsReviewCalculativeValidator.php
@@ -55,8 +55,14 @@ final class IsReviewCalculativeValidator implements ConcreteEntityValidatorInter
    *
    * phpcs:disable Drupal.Commenting.FunctionComment.IncorrectTypeHint
    */
-  public function validate(AbstractEntity $new, AbstractEntity $current): EntityValidationResult {
-    if ($new->getIsReviewCalculative() !== $current->getIsReviewCalculative()) {
+  public function validate(
+    AbstractEntity $new,
+    AbstractEntity $current,
+    bool $checkPermissions
+  ): EntityValidationResult {
+    // Allow flag to be reset when changes to the application are requested.
+    if (($checkPermissions || NULL !== $new->getIsReviewCalculative())
+      && $new->getIsReviewCalculative() !== $current->getIsReviewCalculative()) {
       $fundingCase = $this->fundingCaseManager->get($new->getFundingCaseId());
       Assert::notNull($fundingCase);
       $this->assertPermission($fundingCase);
@@ -70,7 +76,7 @@ final class IsReviewCalculativeValidator implements ConcreteEntityValidatorInter
    *
    * @param \Civi\Funding\Entity\ApplicationProcessEntity $new
    */
-  public function validateNew(AbstractEntity $new): EntityValidationResult {
+  public function validateNew(AbstractEntity $new, bool $checkPermissions): EntityValidationResult {
     if (NULL !== $new->getIsReviewCalculative()) {
       $fundingCase = $this->fundingCaseManager->get($new->getFundingCaseId());
       Assert::notNull($fundingCase);

--- a/Civi/Funding/ApplicationProcess/Validator/IsReviewContentValidator.php
+++ b/Civi/Funding/ApplicationProcess/Validator/IsReviewContentValidator.php
@@ -55,8 +55,13 @@ final class IsReviewContentValidator implements ConcreteEntityValidatorInterface
    *
    * phpcs:disable Drupal.Commenting.FunctionComment.IncorrectTypeHint
    */
-  public function validate(AbstractEntity $new, AbstractEntity $current): EntityValidationResult {
-    if ($new->getIsReviewContent() !== $current->getIsReviewContent()) {
+  public function validate(
+    AbstractEntity $new,
+    AbstractEntity $current,
+    bool $checkPermissions
+  ): EntityValidationResult {
+    if (($checkPermissions || NULL !== $new->getIsReviewContent())
+      && $new->getIsReviewContent() !== $current->getIsReviewContent()) {
       $fundingCase = $this->fundingCaseManager->get($new->getFundingCaseId());
       Assert::notNull($fundingCase);
       $this->assertPermission($fundingCase);
@@ -70,7 +75,7 @@ final class IsReviewContentValidator implements ConcreteEntityValidatorInterface
    *
    * @param \Civi\Funding\Entity\ApplicationProcessEntity $new
    */
-  public function validateNew(AbstractEntity $new): EntityValidationResult {
+  public function validateNew(AbstractEntity $new, bool $checkPermissions): EntityValidationResult {
     if (NULL !== $new->getIsReviewContent()) {
       $fundingCase = $this->fundingCaseManager->get($new->getFundingCaseId());
       Assert::notNull($fundingCase);

--- a/Civi/Funding/ApplicationProcess/Validator/ReviewerCalculativeContactValidator.php
+++ b/Civi/Funding/ApplicationProcess/Validator/ReviewerCalculativeContactValidator.php
@@ -63,7 +63,11 @@ final class ReviewerCalculativeContactValidator implements ConcreteEntityValidat
    *
    * phpcs:disable Drupal.Commenting.FunctionComment.IncorrectTypeHint
    */
-  public function validate(AbstractEntity $new, AbstractEntity $current): EntityValidationResult {
+  public function validate(
+    AbstractEntity $new,
+    AbstractEntity $current,
+    bool $checkPermissions
+  ): EntityValidationResult {
     if ($new->getReviewerCalculativeContactId() === $current->getReviewerCalculativeContactId()) {
       return EntityValidationResult::new();
     }
@@ -84,7 +88,7 @@ final class ReviewerCalculativeContactValidator implements ConcreteEntityValidat
    *
    * @param \Civi\Funding\Entity\ApplicationProcessEntity $new
    */
-  public function validateNew(AbstractEntity $new): EntityValidationResult {
+  public function validateNew(AbstractEntity $new, bool $checkPermissions): EntityValidationResult {
     if (NULL === $new->getReviewerCalculativeContactId()) {
       return EntityValidationResult::new();
     }

--- a/Civi/Funding/ApplicationProcess/Validator/ReviewerContentContactValidator.php
+++ b/Civi/Funding/ApplicationProcess/Validator/ReviewerContentContactValidator.php
@@ -63,7 +63,11 @@ final class ReviewerContentContactValidator implements ConcreteEntityValidatorIn
    *
    * phpcs:disable Drupal.Commenting.FunctionComment.IncorrectTypeHint
    */
-  public function validate(AbstractEntity $new, AbstractEntity $current): EntityValidationResult {
+  public function validate(
+    AbstractEntity $new,
+    AbstractEntity $current,
+    bool $checkPermissions
+  ): EntityValidationResult {
     if ($new->getReviewerContentContactId() === $current->getReviewerContentContactId()) {
       return EntityValidationResult::new();
     }
@@ -84,7 +88,7 @@ final class ReviewerContentContactValidator implements ConcreteEntityValidatorIn
    *
    * @param \Civi\Funding\Entity\ApplicationProcessEntity $new
    */
-  public function validateNew(AbstractEntity $new): EntityValidationResult {
+  public function validateNew(AbstractEntity $new, bool $checkPermissions): EntityValidationResult {
     if (NULL === $new->getReviewerContentContactId()) {
       return EntityValidationResult::new();
     }

--- a/Civi/Funding/PayoutProcess/Validator/DrawdownReviewValidator.php
+++ b/Civi/Funding/PayoutProcess/Validator/DrawdownReviewValidator.php
@@ -67,7 +67,11 @@ final class DrawdownReviewValidator implements ConcreteEntityValidatorInterface 
    *
    * phpcs:disable Drupal.Commenting.FunctionComment.IncorrectTypeHint
    */
-  public function validate(AbstractEntity $new, AbstractEntity $current): EntityValidationResult {
+  public function validate(
+    AbstractEntity $new,
+    AbstractEntity $current,
+    bool $checkPermissions
+  ): EntityValidationResult {
     if ($new->getStatus() !== $current->getStatus()) {
       $fundingCase = $this->getFundingCase($new);
       $this->assertPermission($fundingCase);
@@ -81,7 +85,7 @@ final class DrawdownReviewValidator implements ConcreteEntityValidatorInterface 
    *
    * @param \Civi\Funding\Entity\DrawdownEntity $new
    */
-  public function validateNew(AbstractEntity $new): EntityValidationResult {
+  public function validateNew(AbstractEntity $new, bool $checkPermissions): EntityValidationResult {
     if ('new' !== $new->getStatus()) {
       $fundingCase = $this->getFundingCase($new);
       // Allow clearing reviewers to create a final drawdown when finishing clearing.

--- a/Civi/Funding/PayoutProcess/Validator/DrawdownValidator.php
+++ b/Civi/Funding/PayoutProcess/Validator/DrawdownValidator.php
@@ -68,7 +68,11 @@ final class DrawdownValidator implements ConcreteEntityValidatorInterface {
    *
    * phpcs:disable Drupal.Commenting.FunctionComment.IncorrectTypeHint
    */
-  public function validate(AbstractEntity $new, AbstractEntity $current): EntityValidationResult {
+  public function validate(
+    AbstractEntity $new,
+    AbstractEntity $current,
+    bool $checkPermissions
+  ): EntityValidationResult {
     $payoutProcess = $this->getPayoutProcess($new);
     $this->assertNotClosed($payoutProcess);
 
@@ -98,7 +102,7 @@ final class DrawdownValidator implements ConcreteEntityValidatorInterface {
    * @throws \Civi\API\Exception\UnauthorizedException
    * @throws \CRM_Core_Exception
    */
-  public function validateNew(AbstractEntity $new): EntityValidationResult {
+  public function validateNew(AbstractEntity $new, bool $checkPermissions): EntityValidationResult {
     $payoutProcess = $this->getPayoutProcess($new);
     $this->assertNotClosed($payoutProcess);
 

--- a/Civi/Funding/Validation/EntityValidator.php
+++ b/Civi/Funding/Validation/EntityValidator.php
@@ -37,10 +37,14 @@ final class EntityValidator implements EntityValidatorInterface {
    *
    * @phpstan-ignore-next-line Generic argument of AbstractEntity not defined.
    */
-  public function validate(AbstractEntity $new, AbstractEntity $current): EntityValidationResult {
+  public function validate(
+    AbstractEntity $new,
+    AbstractEntity $current,
+    bool $checkPermissions
+  ): EntityValidationResult {
     $result = new EntityValidationResult();
     foreach ($this->entityValidatorLoader->getValidators(get_class($new)) as $validator) {
-      $result->merge($validator->validate($new, $current));
+      $result->merge($validator->validate($new, $current, $checkPermissions));
     }
 
     return $result;
@@ -51,10 +55,10 @@ final class EntityValidator implements EntityValidatorInterface {
    *
    * @phpstan-ignore-next-line Generic argument of AbstractEntity not defined.
    */
-  public function validateNew(AbstractEntity $new): EntityValidationResult {
+  public function validateNew(AbstractEntity $new, bool $checkPermissions): EntityValidationResult {
     $result = new EntityValidationResult();
     foreach ($this->entityValidatorLoader->getValidators(get_class($new)) as $validator) {
-      $result->merge($validator->validateNew($new));
+      $result->merge($validator->validateNew($new, $checkPermissions));
     }
 
     return $result;

--- a/Civi/Funding/Validation/EntityValidatorInterface.php
+++ b/Civi/Funding/Validation/EntityValidatorInterface.php
@@ -29,12 +29,21 @@ interface EntityValidatorInterface {
   /**
    * @phpstan-param T $new
    * @phpstan-param T $current
+   * @param bool $checkPermissions
+   *   TRUE if the API request is executed with permission check, FALSE otherwise.
    */
-  public function validate(AbstractEntity $new, AbstractEntity $current): EntityValidationResult;
+  public function validate(
+    AbstractEntity $new,
+    AbstractEntity $current,
+    bool $checkPermissions
+  ): EntityValidationResult;
 
   /**
    * @phpstan-param T $new
+   *
+   * @param bool $checkPermissions
+   *    TRUE if the API request is executed with permission check, FALSE otherwise.
    */
-  public function validateNew(AbstractEntity $new): EntityValidationResult;
+  public function validateNew(AbstractEntity $new, bool $checkPermissions): EntityValidationResult;
 
 }

--- a/ang/crmFunding/application/applicationEditor.directive.js
+++ b/ang/crmFunding/application/applicationEditor.directive.js
@@ -180,6 +180,7 @@ fundingModule.directive('fundingApplicationEditor', ['$compile', function($compi
           };
         }
 
+        // @todo Don't call update action directly.
         $scope.updateApplicationProcessField = function (field, value) {
           if ($scope.applicationProcess[field] === value) {
             return;

--- a/ang/crmFunding/clearing/clearingProcess.factory.js
+++ b/ang/crmFunding/clearing/clearingProcess.factory.js
@@ -88,12 +88,6 @@ fundingModule.factory('fundingClearingProcessService', ['crmApi4', function(crmA
     }),
 
     getForm: (id) => crmApi4('FundingClearingProcess', 'getForm', {id}),
-    setValue: (id, field, value) => {
-      let params = {where: [['id', '=', id]], values: {}};
-      params.values[field] = value;
-
-      return crmApi4('FundingClearingProcess', 'update', params);
-    },
     submitForm: (id, data) => crmApi4('FundingClearingProcess', 'submitForm', {id, data}),
     validateForm: (id, data) => crmApi4('FundingClearingProcess', 'validateForm', {id, data}),
 

--- a/tests/phpunit/Civi/Funding/ApplicationProcess/Validator/IsReviewCalculativeValidatorTest.php
+++ b/tests/phpunit/Civi/Funding/ApplicationProcess/Validator/IsReviewCalculativeValidatorTest.php
@@ -58,7 +58,7 @@ final class IsReviewCalculativeValidatorTest extends TestCase {
       'is_review_calculative' => TRUE,
     ]);
 
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateWithoutPermission(): void {
@@ -73,7 +73,7 @@ final class IsReviewCalculativeValidatorTest extends TestCase {
 
     $this->expectException(UnauthorizedException::class);
     $this->expectExceptionMessage('Permission to change calculative review result is missing.');
-    $this->validator->validate($new, $current)->isValid();
+    $this->validator->validate($new, $current, TRUE)->isValid();
   }
 
   public function testValidateWithPermission(): void {
@@ -87,7 +87,7 @@ final class IsReviewCalculativeValidatorTest extends TestCase {
     ]);
 
     $this->fundingCase->setValues(['permissions' => ['review_calculative']] + $this->fundingCase->toArray());
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateNewNotSet(): void {
@@ -97,7 +97,7 @@ final class IsReviewCalculativeValidatorTest extends TestCase {
       'is_review_calculative' => NULL,
     ]);
 
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewWithoutPermission(): void {
@@ -109,7 +109,7 @@ final class IsReviewCalculativeValidatorTest extends TestCase {
 
     $this->expectException(UnauthorizedException::class);
     $this->expectExceptionMessage('Permission to change calculative review result is missing.');
-    $this->validator->validateNew($new)->isValid();
+    $this->validator->validateNew($new, TRUE)->isValid();
   }
 
   public function testValidateNewWithPermission(): void {
@@ -120,7 +120,38 @@ final class IsReviewCalculativeValidatorTest extends TestCase {
     ]);
 
     $this->fundingCase->setValues(['permissions' => ['review_calculative']] + $this->fundingCase->toArray());
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
+  }
+
+  public function testValidateResetWithoutPermissionCheckIsValid(): void {
+    $new = ApplicationProcessFactory::createApplicationProcess([
+      'title' => 'new',
+      'is_review_calculative' => NULL,
+    ]);
+    $current = ApplicationProcessFactory::createApplicationProcess([
+      'title' => 'current',
+      'is_review_calculative' => TRUE,
+    ]);
+
+    $this->fundingCase->setValues(['permissions' => ['test']] + $this->fundingCase->toArray());
+    static::assertTrue($this->validator->validate($new, $current, FALSE)->isValid());
+  }
+
+  public function testValidateChangeWithoutPermissionCheckIsInvalid(): void {
+    $new = ApplicationProcessFactory::createApplicationProcess([
+      'title' => 'new',
+      'is_review_calculative' => TRUE,
+    ]);
+    $current = ApplicationProcessFactory::createApplicationProcess([
+      'title' => 'current',
+      'is_review_calculative' => NULL,
+    ]);
+
+    $this->fundingCase->setValues(['permissions' => ['test']] + $this->fundingCase->toArray());
+
+    $this->expectException(UnauthorizedException::class);
+    $this->expectExceptionMessage('Permission to change calculative review result is missing.');
+    static::assertFalse($this->validator->validate($new, $current, FALSE)->isValid());
   }
 
 }

--- a/tests/phpunit/Civi/Funding/ApplicationProcess/Validator/IsReviewContentValidatorTest.php
+++ b/tests/phpunit/Civi/Funding/ApplicationProcess/Validator/IsReviewContentValidatorTest.php
@@ -58,7 +58,7 @@ final class IsReviewContentValidatorTest extends TestCase {
       'is_review_content' => TRUE,
     ]);
 
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateWithoutPermission(): void {
@@ -73,7 +73,7 @@ final class IsReviewContentValidatorTest extends TestCase {
 
     $this->expectException(UnauthorizedException::class);
     $this->expectExceptionMessage('Permission to change content review result is missing.');
-    $this->validator->validate($new, $current)->isValid();
+    $this->validator->validate($new, $current, TRUE)->isValid();
   }
 
   public function testValidateWithPermission(): void {
@@ -87,7 +87,7 @@ final class IsReviewContentValidatorTest extends TestCase {
     ]);
 
     $this->fundingCase->setValues(['permissions' => ['review_content']] + $this->fundingCase->toArray());
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateNewNotSet(): void {
@@ -97,7 +97,7 @@ final class IsReviewContentValidatorTest extends TestCase {
       'is_review_content' => NULL,
     ]);
 
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewWithoutPermission(): void {
@@ -109,7 +109,7 @@ final class IsReviewContentValidatorTest extends TestCase {
 
     $this->expectException(UnauthorizedException::class);
     $this->expectExceptionMessage('Permission to change content review result is missing.');
-    $this->validator->validateNew($new)->isValid();
+    $this->validator->validateNew($new, TRUE)->isValid();
   }
 
   public function testValidateNewWithPermission(): void {
@@ -120,7 +120,38 @@ final class IsReviewContentValidatorTest extends TestCase {
     ]);
 
     $this->fundingCase->setValues(['permissions' => ['review_content']] + $this->fundingCase->toArray());
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
+  }
+
+  public function testValidateResetWithoutPermissionCheckIsValid(): void {
+    $new = ApplicationProcessFactory::createApplicationProcess([
+      'title' => 'new',
+      'is_review_content' => NULL,
+    ]);
+    $current = ApplicationProcessFactory::createApplicationProcess([
+      'title' => 'current',
+      'is_review_content' => TRUE,
+    ]);
+
+    $this->fundingCase->setValues(['permissions' => ['test']] + $this->fundingCase->toArray());
+    static::assertTrue($this->validator->validate($new, $current, FALSE)->isValid());
+  }
+
+  public function testValidateChangeWithoutPermissionCheckIsInvalid(): void {
+    $new = ApplicationProcessFactory::createApplicationProcess([
+      'title' => 'new',
+      'is_review_content' => TRUE,
+    ]);
+    $current = ApplicationProcessFactory::createApplicationProcess([
+      'title' => 'current',
+      'is_review_content' => NULL,
+    ]);
+
+    $this->fundingCase->setValues(['permissions' => ['test']] + $this->fundingCase->toArray());
+
+    $this->expectException(UnauthorizedException::class);
+    $this->expectExceptionMessage('Permission to change content review result is missing.');
+    static::assertFalse($this->validator->validate($new, $current, FALSE)->isValid());
   }
 
 }

--- a/tests/phpunit/Civi/Funding/ApplicationProcess/Validator/ReviewerCalculativeContactValidatorTest.php
+++ b/tests/phpunit/Civi/Funding/ApplicationProcess/Validator/ReviewerCalculativeContactValidatorTest.php
@@ -70,7 +70,7 @@ final class ReviewerCalculativeContactValidatorTest extends TestCase {
       'reviewer_calc_contact_id' => 1,
     ]);
 
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateWithoutPermission(): void {
@@ -85,7 +85,7 @@ final class ReviewerCalculativeContactValidatorTest extends TestCase {
 
     $this->expectException(UnauthorizedException::class);
     $this->expectExceptionMessage('Permission to change calculative reviewer is missing.');
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateWithPermission(): void {
@@ -102,7 +102,7 @@ final class ReviewerCalculativeContactValidatorTest extends TestCase {
       ->with($this->fundingCase, ['review_calculative'])
       ->willReturn([2 => 'foo', 3 => 'bar']);
     $this->fundingCase->setValues(['permissions' => ['review_calculative']] + $this->fundingCase->toArray());
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateContactNotAllowed(): void {
@@ -119,7 +119,7 @@ final class ReviewerCalculativeContactValidatorTest extends TestCase {
       ->with($this->fundingCase, ['review_calculative'])
       ->willReturn([3 => 'bar']);
     $this->fundingCase->setValues(['permissions' => ['review_calculative']] + $this->fundingCase->toArray());
-    $result = $this->validator->validate($new, $current);
+    $result = $this->validator->validate($new, $current, TRUE);
     static::assertFalse($result->isValid());
     static::assertEquals([
       'reviewer_calc_contact_id' => [
@@ -137,7 +137,7 @@ final class ReviewerCalculativeContactValidatorTest extends TestCase {
       'reviewer_calc_contact_id' => NULL,
     ]);
 
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewWithoutPermission(): void {
@@ -149,7 +149,7 @@ final class ReviewerCalculativeContactValidatorTest extends TestCase {
 
     $this->expectException(UnauthorizedException::class);
     $this->expectExceptionMessage('Permission to change calculative reviewer is missing.');
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewWithPermission(): void {
@@ -163,7 +163,7 @@ final class ReviewerCalculativeContactValidatorTest extends TestCase {
       ->with($this->fundingCase, ['review_calculative'])
       ->willReturn([1 => 'foo']);
     $this->fundingCase->setValues(['permissions' => ['review_calculative']] + $this->fundingCase->toArray());
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewContactNotAllowed(): void {
@@ -177,7 +177,7 @@ final class ReviewerCalculativeContactValidatorTest extends TestCase {
       ->with($this->fundingCase, ['review_calculative'])
       ->willReturn([2 => 'foo']);
     $this->fundingCase->setValues(['permissions' => ['review_calculative']] + $this->fundingCase->toArray());
-    $result = $this->validator->validateNew($new);
+    $result = $this->validator->validateNew($new, TRUE);
     static::assertFalse($result->isValid());
     static::assertEquals([
       'reviewer_calc_contact_id' => [

--- a/tests/phpunit/Civi/Funding/ApplicationProcess/Validator/ReviewerContentContactValidatorTest.php
+++ b/tests/phpunit/Civi/Funding/ApplicationProcess/Validator/ReviewerContentContactValidatorTest.php
@@ -70,7 +70,7 @@ final class ReviewerContentContactValidatorTest extends TestCase {
       'reviewer_cont_contact_id' => 1,
     ]);
 
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateWithoutPermission(): void {
@@ -85,7 +85,7 @@ final class ReviewerContentContactValidatorTest extends TestCase {
 
     $this->expectException(UnauthorizedException::class);
     $this->expectExceptionMessage('Permission to change content reviewer is missing.');
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateWithPermission(): void {
@@ -102,7 +102,7 @@ final class ReviewerContentContactValidatorTest extends TestCase {
       ->with($this->fundingCase, ['review_content'])
       ->willReturn([2 => 'foo', 3 => 'bar']);
     $this->fundingCase->setValues(['permissions' => ['review_content']] + $this->fundingCase->toArray());
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateContactNotAllowed(): void {
@@ -119,7 +119,7 @@ final class ReviewerContentContactValidatorTest extends TestCase {
       ->with($this->fundingCase, ['review_content'])
       ->willReturn([3 => 'bar']);
     $this->fundingCase->setValues(['permissions' => ['review_content']] + $this->fundingCase->toArray());
-    $result = $this->validator->validate($new, $current);
+    $result = $this->validator->validate($new, $current, TRUE);
     static::assertFalse($result->isValid());
     static::assertEquals([
       'reviewer_cont_contact_id' => [
@@ -137,7 +137,7 @@ final class ReviewerContentContactValidatorTest extends TestCase {
       'reviewer_cont_contact_id' => NULL,
     ]);
 
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewWithoutPermission(): void {
@@ -149,7 +149,7 @@ final class ReviewerContentContactValidatorTest extends TestCase {
 
     $this->expectException(UnauthorizedException::class);
     $this->expectExceptionMessage('Permission to change content reviewer is missing.');
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewWithPermission(): void {
@@ -163,7 +163,7 @@ final class ReviewerContentContactValidatorTest extends TestCase {
       ->with($this->fundingCase, ['review_content'])
       ->willReturn([1 => 'foo']);
     $this->fundingCase->setValues(['permissions' => ['review_content']] + $this->fundingCase->toArray());
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewContactNotAllowed(): void {
@@ -177,7 +177,7 @@ final class ReviewerContentContactValidatorTest extends TestCase {
       ->with($this->fundingCase, ['review_content'])
       ->willReturn([2 => 'foo']);
     $this->fundingCase->setValues(['permissions' => ['review_content']] + $this->fundingCase->toArray());
-    $result = $this->validator->validateNew($new);
+    $result = $this->validator->validateNew($new, TRUE);
     static::assertFalse($result->isValid());
     static::assertEquals([
       'reviewer_cont_contact_id' => [

--- a/tests/phpunit/Civi/Funding/PayoutProcess/Validator/DrawdownReviewValidatorTest.php
+++ b/tests/phpunit/Civi/Funding/PayoutProcess/Validator/DrawdownReviewValidatorTest.php
@@ -65,7 +65,7 @@ final class DrawdownReviewValidatorTest extends TestCase {
     $new = DrawdownFactory::create(['status' => 'accepted']);
     $current = DrawdownFactory::create(['status' => 'accepted']);
 
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateWithoutPermission(): void {
@@ -74,7 +74,7 @@ final class DrawdownReviewValidatorTest extends TestCase {
 
     $this->expectException(UnauthorizedException::class);
     $this->expectExceptionMessage('Permission to change drawdown status is missing.');
-    $this->validator->validate($new, $current)->isValid();
+    $this->validator->validate($new, $current, TRUE)->isValid();
   }
 
   public function testValidateWithPermission(): void {
@@ -82,12 +82,12 @@ final class DrawdownReviewValidatorTest extends TestCase {
     $current = DrawdownFactory::create(['status' => 'accepted']);
 
     $this->fundingCase->setValues(['permissions' => ['review_drawdown']] + $this->fundingCase->toArray());
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateNew(): void {
     $new = DrawdownFactory::create(['status' => 'new']);
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewWithoutPermission(): void {
@@ -95,14 +95,14 @@ final class DrawdownReviewValidatorTest extends TestCase {
 
     $this->expectException(UnauthorizedException::class);
     $this->expectExceptionMessage('Permission to change drawdown status is missing.');
-    $this->validator->validateNew($new)->isValid();
+    $this->validator->validateNew($new, TRUE)->isValid();
   }
 
   public function testValidateNewWithPermission(): void {
     $new = DrawdownFactory::create(['status' => 'accepted']);
 
     $this->fundingCase->setValues(['permissions' => ['review_drawdown']] + $this->fundingCase->toArray());
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
 }

--- a/tests/phpunit/Civi/Funding/PayoutProcess/Validator/DrawdownValidatorTest.php
+++ b/tests/phpunit/Civi/Funding/PayoutProcess/Validator/DrawdownValidatorTest.php
@@ -74,7 +74,7 @@ final class DrawdownValidatorTest extends TestCase {
     $new = DrawdownFactory::create();
     $current = DrawdownFactory::create();
 
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateNewWithoutPermission(): void {
@@ -83,7 +83,7 @@ final class DrawdownValidatorTest extends TestCase {
     $this->expectException(UnauthorizedException::class);
     $this->expectExceptionMessage('Permission to create drawdown is missing.');
 
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewWithPermission(): void {
@@ -94,7 +94,7 @@ final class DrawdownValidatorTest extends TestCase {
       ->with($this->payoutProcess)
       ->willReturn(10.1);
 
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewClosed(): void {
@@ -105,7 +105,7 @@ final class DrawdownValidatorTest extends TestCase {
     $this->expectException(UnauthorizedException::class);
     $this->expectExceptionMessage('Payout process is closed.');
 
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateAmountLessThanZero(): void {
@@ -113,7 +113,7 @@ final class DrawdownValidatorTest extends TestCase {
     $new = DrawdownFactory::create(['amount' => -0.1]);
     $this->fundingCase->setValues(['permissions' => ['drawdown_create']] + $this->fundingCase->toArray());
 
-    $result = $this->validator->validate($new, $current);
+    $result = $this->validator->validate($new, $current, TRUE);
     static::assertFalse($result->isValid());
     static::assertEquals([
       'amount' => [
@@ -131,7 +131,7 @@ final class DrawdownValidatorTest extends TestCase {
       'permissions' => [ClearingProcessPermissions::REVIEW_CONTENT],
     ] + $this->fundingCase->toArray());
 
-    $result = $this->validator->validate($new, $current);
+    $result = $this->validator->validate($new, $current, TRUE);
     static::assertTrue($result->isValid());
   }
 
@@ -140,7 +140,7 @@ final class DrawdownValidatorTest extends TestCase {
     $new = DrawdownFactory::create(['amount' => 0.0]);
     $this->fundingCase->setValues(['permissions' => ['drawdown_create']] + $this->fundingCase->toArray());
 
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateAmountUnchanged(): void {
@@ -148,7 +148,7 @@ final class DrawdownValidatorTest extends TestCase {
     $new = DrawdownFactory::create(['status' => 'accepted']);
     $this->fundingCase->setValues(['permissions' => ['drawdown_create']] + $this->fundingCase->toArray());
 
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateAmountReduced(): void {
@@ -156,7 +156,7 @@ final class DrawdownValidatorTest extends TestCase {
     $new = DrawdownFactory::create(['amount' => 9.9]);
     $this->fundingCase->setValues(['permissions' => ['drawdown_create']] + $this->fundingCase->toArray());
 
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateAmountIncreased(): void {
@@ -168,7 +168,7 @@ final class DrawdownValidatorTest extends TestCase {
       ->with($this->payoutProcess)
       ->willReturn(0.1);
 
-    static::assertTrue($this->validator->validate($new, $current)->isValid());
+    static::assertTrue($this->validator->validate($new, $current, TRUE)->isValid());
   }
 
   public function testValidateAmountExceedsLimit(): void {
@@ -180,7 +180,7 @@ final class DrawdownValidatorTest extends TestCase {
       ->with($this->payoutProcess)
       ->willReturn(0.01);
 
-    $result = $this->validator->validate($new, $current);
+    $result = $this->validator->validate($new, $current, TRUE);
     static::assertFalse($result->isValid());
     static::assertEquals([
       'amount' => [
@@ -199,14 +199,14 @@ final class DrawdownValidatorTest extends TestCase {
       ->with($this->payoutProcess)
       ->willReturn(10.1);
 
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewAmountLessThanZero(): void {
     $new = DrawdownFactory::create(['amount' => -0.1]);
     $this->fundingCase->setValues(['permissions' => ['drawdown_create']] + $this->fundingCase->toArray());
 
-    $result = $this->validator->validateNew($new);
+    $result = $this->validator->validateNew($new, TRUE);
     static::assertFalse($result->isValid());
     static::assertEquals([
       'amount' => [
@@ -223,7 +223,7 @@ final class DrawdownValidatorTest extends TestCase {
       'permissions' => [ClearingProcessPermissions::REVIEW_CALCULATIVE],
     ] + $this->fundingCase->toArray());
 
-    $result = $this->validator->validateNew($new);
+    $result = $this->validator->validateNew($new, TRUE);
     static::assertTrue($result->isValid());
   }
 
@@ -235,7 +235,7 @@ final class DrawdownValidatorTest extends TestCase {
       ->with($this->payoutProcess)
       ->willReturn(10.1);
 
-    static::assertTrue($this->validator->validateNew($new)->isValid());
+    static::assertTrue($this->validator->validateNew($new, TRUE)->isValid());
   }
 
   public function testValidateNewExceedsLimit(): void {
@@ -246,7 +246,7 @@ final class DrawdownValidatorTest extends TestCase {
       ->with($this->payoutProcess)
       ->willReturn(10.0);
 
-    $result = $this->validator->validateNew($new);
+    $result = $this->validator->validateNew($new, TRUE);
     static::assertFalse($result->isValid());
     static::assertEquals([
       'amount' => [

--- a/tests/phpunit/Civi/Funding/Validation/EntityValidatorTest.php
+++ b/tests/phpunit/Civi/Funding/Validation/EntityValidatorTest.php
@@ -53,12 +53,12 @@ final class EntityValidatorTest extends TestCase {
     $current = FundingProgramFactory::createFundingProgram(['title' => 'Current']);
 
     $error1 = EntityValidationError::new('test1', 'Foo1');
-    $validatorMock1->method('validate')->with($new, $current)->willReturn(EntityValidationResult::new($error1));
+    $validatorMock1->method('validate')->with($new, $current, TRUE)->willReturn(EntityValidationResult::new($error1));
 
     $error2 = EntityValidationError::new('test2', 'Foo2');
-    $validatorMock2->method('validate')->with($new, $current)->willReturn(EntityValidationResult::new($error2));
+    $validatorMock2->method('validate')->with($new, $current, TRUE)->willReturn(EntityValidationResult::new($error2));
 
-    $result = $this->validator->validate($new, $current);
+    $result = $this->validator->validate($new, $current, TRUE);
     static::assertSame(['test1' => [$error1], 'test2' => [$error2]], $result->getErrors());
   }
 
@@ -72,12 +72,12 @@ final class EntityValidatorTest extends TestCase {
     $new = FundingProgramFactory::createFundingProgram(['title' => 'New']);
 
     $error1 = EntityValidationError::new('test1', 'Foo1');
-    $validatorMock1->method('validateNew')->with($new)->willReturn(EntityValidationResult::new($error1));
+    $validatorMock1->method('validateNew')->with($new, TRUE)->willReturn(EntityValidationResult::new($error1));
 
     $error2 = EntityValidationError::new('test2', 'Foo2');
-    $validatorMock2->method('validateNew')->with($new)->willReturn(EntityValidationResult::new($error2));
+    $validatorMock2->method('validateNew')->with($new, TRUE)->willReturn(EntityValidationResult::new($error2));
 
-    $result = $this->validator->validateNew($new);
+    $result = $this->validator->validateNew($new, TRUE);
     static::assertSame(['test1' => [$error1], 'test2' => [$error2]], $result->getErrors());
   }
 


### PR DESCRIPTION
When changes to an application are requested, the flags for calculative and content review are reset. If it's allowed to request changes, but not for a specific review flag, the action fails (if the review flag is set).

systopia-reference: 28213