### PR TITLE
Don't reset amount admitted and status of clearing item if unchanged

### DIFF
--- a/Civi/Funding/ClearingProcess/Form/ClearingFormGenerator.php
+++ b/Civi/Funding/ClearingProcess/Form/ClearingFormGenerator.php
@@ -46,8 +46,8 @@ use Webmozart\Assert\Assert;
  *   paymentDate: string,
  *   recipient: string,
  *   reason: string,
- *   amount: float,
- *   amountAdmitted: ?float,
+ *   amount: float|int,
+ *   amountAdmitted: float|int|null,
  * }
  *
  * @phpstan-type clearingFormDataT array{

--- a/Civi/Funding/ClearingProcess/Handler/Helper/AbstractClearingItemsFormDataPersister.php
+++ b/Civi/Funding/ClearingProcess/Handler/Helper/AbstractClearingItemsFormDataPersister.php
@@ -260,10 +260,10 @@ abstract class AbstractClearingItemsFormDataPersister {
   private function isClearingItemChanged(AbstractClearingItemEntity $clearingItem, array $record, ?int $fileId): bool {
     return $clearingItem->getFileId() !== $fileId
       || $clearingItem->getReceiptNumber() !== $record['receiptNumber']
-      || $clearingItem->getPaymentDate() !== $record['paymentDate']
+      || $clearingItem->get('payment_date') !== $record['paymentDate']
       || $clearingItem->getRecipient() !== $record['recipient']
       || $clearingItem->getReason() !== $record['reason']
-      || $clearingItem->getAmount() !== $record['amount'];
+      || abs($clearingItem->getAmount() - $record['amount']) >= PHP_FLOAT_EPSILON;
   }
 
 }


### PR DESCRIPTION
It was intended that the amount admitted and the status of a clearing item are unchanged if the submitted values of the clearing item are unchanged. Though that didn't work, yet.

systopia-reference: 28323