### PR TITLE
searchkit: Do not override entityinfo properties

### DIFF
--- a/ang/crmFunding/application/applicationSearchTasksMenu.decorator.js
+++ b/ang/crmFunding/application/applicationSearchTasksMenu.decorator.js
@@ -68,11 +68,9 @@ fundingModule.directive('fundingApplicationTasksDecorator', function() {
 
         let searchKitTasks;
         taskManager.getMetadata().then(() => {
-          taskManager.entityInfo = {
-            title: ts('Application'),
-            title_plural: ts('Applications'),
-          };
-
+          taskManager.entityInfo = taskManager.entityInfo || {};
+          taskManager.entityInfo.title = ts('Application');
+          taskManager.entityInfo.title_plural = ts('Applications');
           searchKitTasks = taskManager.tasks;
         });
 

--- a/ang/crmFunding/clearing/clearingSearchTasksMenu.decorator.js
+++ b/ang/crmFunding/clearing/clearingSearchTasksMenu.decorator.js
@@ -68,11 +68,9 @@ fundingModule.directive('fundingClearingTasksDecorator', function() {
 
         let searchKitTasks;
         taskManager.getMetadata().then(() => {
-          taskManager.entityInfo = {
-            title: ts('Clearing'),
-            title_plural: ts('Clearings'),
-          };
-
+          taskManager.entityInfo = taskManager.entityInfo || {};
+          taskManager.entityInfo.title = ts('Clearing');
+          taskManager.entityInfo.title_plural = ts('Clearings');
           searchKitTasks = taskManager.tasks;
         });
 

--- a/ang/crmFunding/drawdown/drawdownSearchTasksMenu.decorator.js
+++ b/ang/crmFunding/drawdown/drawdownSearchTasksMenu.decorator.js
@@ -68,11 +68,9 @@ fundingModule.directive('fundingDrawdownTasksDecorator', function() {
 
         let searchKitTasks;
         taskManager.getMetadata().then(() => {
-          taskManager.entityInfo = {
-            title: ts('Drawdown'),
-            title_plural: ts('Drawdowns'),
-          };
-
+          taskManager.entityInfo = taskManager.entityInfo || {};
+          taskManager.entityInfo.title = ts('Drawdown');
+          taskManager.entityInfo.title_plural = ts('Drawdowns');
           searchKitTasks = taskManager.tasks;
         });
 


### PR DESCRIPTION
The decorator removes properties which are used by example civioffice to create document.


The origin entityInfo object for application process entity. (`example.org/civicrm/search#/display/funding_case_application_processes`)

```
{
  "name": "FundingApplicationProcess",
  "title": "Application Process",
  "title_plural": "Application Processes",
  "primary_key": [
    "id"
  ]
}
```