### PR TITLE
When drawdown is accepted/rejected from drawdown list redirect back to drawdown list

### DIFF
--- a/Civi/Funding/Controller/DrawdownAcceptController.php
+++ b/Civi/Funding/Controller/DrawdownAcceptController.php
@@ -64,14 +64,14 @@ final class DrawdownAcceptController implements PageControllerInterface {
       throw new BadRequestHttpException('Invalid drawdown ID');
     }
 
-    return $this->accept((int) $drawdownId);
+    return $this->accept((int) $drawdownId, $request);
   }
 
   /**
    * @throws \CRM_Core_Exception
    * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
    */
-  private function accept(int $drawdownId): Response {
+  private function accept(int $drawdownId, Request $request): Response {
     $drawdown = $this->drawdownManager->get($drawdownId);
     if (NULL === $drawdown) {
       throw new AccessDeniedHttpException();
@@ -84,9 +84,14 @@ final class DrawdownAcceptController implements PageControllerInterface {
       'id' => $drawdownId,
     ]);
 
-    return new RedirectResponse($this->urlGenerator->generate(
-      'civicrm/a#/funding/case/' . $payoutProcess->getFundingCaseId()
-    ));
+    $redirectUrl = $request->headers->get('Referer') ?? '';
+    if (!str_contains($redirectUrl, '/civicrm/funding/')) {
+      $redirectUrl = $this->urlGenerator->generate(
+        'civicrm/a#/funding/case/' . $payoutProcess->getFundingCaseId()
+      );
+    }
+
+    return new RedirectResponse($redirectUrl);
   }
 
 }

--- a/Civi/Funding/Controller/DrawdownRejectController.php
+++ b/Civi/Funding/Controller/DrawdownRejectController.php
@@ -64,14 +64,14 @@ final class DrawdownRejectController implements PageControllerInterface {
       throw new BadRequestHttpException('Invalid drawdown ID');
     }
 
-    return $this->reject((int) $drawdownId);
+    return $this->reject((int) $drawdownId, $request);
   }
 
   /**
    * @throws \CRM_Core_Exception
    * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
    */
-  private function reject(int $drawdownId): Response {
+  private function reject(int $drawdownId, Request $request): Response {
     $drawdown = $this->drawdownManager->get($drawdownId);
     if (NULL === $drawdown) {
       throw new AccessDeniedHttpException();
@@ -84,9 +84,14 @@ final class DrawdownRejectController implements PageControllerInterface {
       'id' => $drawdownId,
     ]);
 
-    return new RedirectResponse($this->urlGenerator->generate(
-      'civicrm/a#/funding/case/' . $payoutProcess->getFundingCaseId()
-    ));
+    $redirectUrl = $request->headers->get('Referer') ?? '';
+    if (!str_contains($redirectUrl, '/civicrm/funding/')) {
+      $redirectUrl = $this->urlGenerator->generate(
+        'civicrm/a#/funding/case/' . $payoutProcess->getFundingCaseId()
+      );
+    }
+
+    return new RedirectResponse($redirectUrl);
   }
 
 }

--- a/tests/phpunit/Civi/Funding/Controller/DrawdownAcceptControllerTest.php
+++ b/tests/phpunit/Civi/Funding/Controller/DrawdownAcceptControllerTest.php
@@ -75,7 +75,10 @@ final class DrawdownAcceptControllerTest extends TestCase {
     );
   }
 
-  public function testHandle(): void {
+  /**
+   * @dataProvider provideReferrer
+   */
+  public function testHandle(?string $referrer, ?string $expectedRedirect = NULL): void {
     $drawdown = DrawdownFactory::create();
     $this->drawdownManagerMock->method('get')
       ->with($drawdown->getId())
@@ -94,9 +97,23 @@ final class DrawdownAcceptControllerTest extends TestCase {
       ->with('civicrm/a#/funding/case/' . $payoutProcess->getFundingCaseId())
       ->willReturn('http://test');
 
-    $response = $this->controller->handle(new Request(['drawdownId' => $drawdown->getId()]));
+    $request = new Request(['drawdownId' => $drawdown->getId()]);
+    if (NULL !== $referrer) {
+      $request->headers->set('Referer', $referrer);
+    }
+
+    $response = $this->controller->handle($request);
     static::assertInstanceOf(RedirectResponse::class, $response);
-    static::assertSame('http://test', $response->getTargetUrl());
+    static::assertSame($expectedRedirect ?? 'http://test', $response->getTargetUrl());
+  }
+
+  /**
+   * @phpstan-return iterable<array{string|null, 1?: string}>
+   */
+  public function provideReferrer(): iterable {
+    yield [NULL];
+    yield ['http://test/civicrm/funding/abc', 'http://test/civicrm/funding/abc'];
+    yield ['http://test/civicrm/a'];
   }
 
   public function testHandleInvalidDrawdownId(): void {


### PR DESCRIPTION
Previously a redirect was always done to `civicrm/a#/funding/case/<funding case ID>`.

Technical note: The implementation depends on the `Referer` header.

systopia-reference: 29468