### PR TITLE
Fix funding case type template upload with CiviCRM >=6.3

### DIFF
--- a/Civi/Funding/Api4/Action/FundingCaseType/UpdateAction.php
+++ b/Civi/Funding/Api4/Action/FundingCaseType/UpdateAction.php
@@ -97,20 +97,19 @@ final class UpdateAction extends DAOUpdateAction {
       ->setWhere($this->getWhere())
       ->execute();
 
-    if ($result->count() > 1) {
+    if ($result->count() !== 1) {
       throw new \InvalidArgumentException(
         'Template can only be updated for a single funding case type'
       );
     }
 
-    if ($result->count() === 1) {
-      $previousFileId = $result->single()[$templateIdFieldName];
-      if ($previousFileId !== NULL && $previousFileId !== $templateFileId) {
-        $fundingCaseTypeId = $result->single()['id'];
-        $this->attachmentManager->deleteById($previousFileId, 'civicrm_funding_case_type', $fundingCaseTypeId);
-      }
+    $fundingCaseTypeId = $result->single()['id'];
+    $previousFileId = $result->single()[$templateIdFieldName];
+    if ($previousFileId !== NULL && $previousFileId !== $templateFileId) {
+      $this->attachmentManager->deleteById($previousFileId, 'civicrm_funding_case_type', $fundingCaseTypeId);
     }
 
+    $this->attachmentManager->attachById($templateFileId, 'civicrm_funding_case_type', $fundingCaseTypeId);
     $this->api4->updateEntity(File::getEntityName(), $templateFileId, [
       'file_type_id:name' => $fileType,
     ]);

--- a/Civi/Funding/FundingAttachmentManager.php
+++ b/Civi/Funding/FundingAttachmentManager.php
@@ -19,6 +19,7 @@ declare(strict_types = 1);
 
 namespace Civi\Funding;
 
+use Civi\Api4\EntityFile;
 use Civi\Funding\Entity\AttachmentEntity;
 use Civi\RemoteTools\Api3\Api3Interface;
 use Civi\RemoteTools\Api4\Api4Interface;
@@ -35,6 +36,23 @@ final class FundingAttachmentManager implements FundingAttachmentManagerInterfac
   ) {
     $this->api3 = $api3;
     $this->api4 = $api4;
+  }
+
+  public function attachById(int $id, string $entityTable, int $entityId): void {
+    $this->api4->execute(EntityFile::getEntityName(), 'save', [
+      'records' => [
+        [
+          'entity_table' => $entityTable,
+          'entity_id' => $entityId,
+          'file_id' => $id,
+        ],
+      ],
+      'match' => [
+        'entity_table',
+        'entity_id',
+        'file_id',
+      ],
+    ]);
   }
 
   /**

--- a/Civi/Funding/FundingAttachmentManagerInterface.php
+++ b/Civi/Funding/FundingAttachmentManagerInterface.php
@@ -23,6 +23,8 @@ use Civi\Funding\Entity\AttachmentEntity;
 
 interface FundingAttachmentManagerInterface {
 
+  public function attachById(int $id, string $entityTable, int $entityId): void;
+
   /**
    * @phpstan-param array{
    *   file_type_id?: int,

--- a/tests/phpunit/Civi/Api4/FundingCaseTypeTest.php
+++ b/tests/phpunit/Civi/Api4/FundingCaseTypeTest.php
@@ -144,25 +144,38 @@ final class FundingCaseTypeTest extends AbstractFundingHeadlessTestCase {
       ->single()['file_type_id:name'];
     static::assertSame(FileTypeNames::PAYBACK_CLAIM_TEMPLATE, $fileTypeName);
 
-    $attachment2 = AttachmentFixture::addFixture(
-      'civicrm_funding_case_type',
-      $fundingCaseType->getId(),
-      E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx')
-    );
+    $file2 = File::create(FALSE)
+      ->setValues([
+        'uri' => 'test',
+        'mime_type' => 'inode/x-empty',
+      ])->execute()->single();
 
-    // Previous file shall be deleted.
+    // New file shall be attached and the file type shall be set. Previous file shall be deleted.
     $result = FundingCaseType::update()
-      ->addValue('payback_claim_template_file_id', $attachment2->getId())
+      ->addValue('payback_claim_template_file_id', $file2['id'])
       ->addWhere('id', '=', $fundingCaseType->getId())
       ->execute();
-    static::assertSame($attachment2->getId(), $result->single()['payback_claim_template_file_id']);
+    static::assertSame($file2['id'], $result->single()['payback_claim_template_file_id']);
+
+    static::assertSame($file2['id'], FundingCaseType::get()
+      ->addSelect('payback_claim_template_file_id')
+      ->addWhere('id', '=', $fundingCaseType->getId())
+      ->execute()->single()['payback_claim_template_file_id']
+    );
 
     $fileTypeName = File::get(FALSE)
       ->addSelect('file_type_id:name')
-      ->addWhere('id', '=', $attachment2->getId())
+      ->addWhere('id', '=', $file2['id'])
       ->execute()
       ->single()['file_type_id:name'];
     static::assertSame(FileTypeNames::PAYBACK_CLAIM_TEMPLATE, $fileTypeName);
+
+    static::assertCount(1, EntityFile::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('file_id', '=', $file2['id'])
+      ->addWhere('entity_table', '=', 'civicrm_funding_case_type')
+      ->addWhere('entity_id', '=', $fundingCaseType->getId())
+      ->execute());
 
     static::assertCount(
       0,
@@ -191,25 +204,38 @@ final class FundingCaseTypeTest extends AbstractFundingHeadlessTestCase {
       ->single()['file_type_id:name'];
     static::assertSame(FileTypeNames::PAYMENT_INSTRUCTION_TEMPLATE, $fileTypeName);
 
-    $attachment2 = AttachmentFixture::addFixture(
-      'civicrm_funding_case_type',
-      $fundingCaseType->getId(),
-      E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx')
-    );
+    $file2 = File::create(FALSE)
+      ->setValues([
+        'uri' => 'test',
+        'mime_type' => 'inode/x-empty',
+      ])->execute()->single();
 
-    // Previous file shall be deleted.
+    // New file shall be attached and the file type shall be set. Previous file shall be deleted.
     $result = FundingCaseType::update()
-      ->addValue('payment_instruction_template_file_id', $attachment2->getId())
+      ->addValue('payment_instruction_template_file_id', $file2['id'])
       ->addWhere('id', '=', $fundingCaseType->getId())
       ->execute();
-    static::assertSame($attachment2->getId(), $result->single()['payment_instruction_template_file_id']);
+    static::assertSame($file2['id'], $result->single()['payment_instruction_template_file_id']);
+
+    static::assertSame($file2['id'], FundingCaseType::get()
+      ->addSelect('payment_instruction_template_file_id')
+      ->addWhere('id', '=', $fundingCaseType->getId())
+      ->execute()->single()['payment_instruction_template_file_id']
+    );
 
     $fileTypeName = File::get(FALSE)
       ->addSelect('file_type_id:name')
-      ->addWhere('id', '=', $attachment2->getId())
+      ->addWhere('id', '=', $file2['id'])
       ->execute()
       ->single()['file_type_id:name'];
     static::assertSame(FileTypeNames::PAYMENT_INSTRUCTION_TEMPLATE, $fileTypeName);
+
+    static::assertCount(1, EntityFile::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('file_id', '=', $file2['id'])
+      ->addWhere('entity_table', '=', 'civicrm_funding_case_type')
+      ->addWhere('entity_id', '=', $fundingCaseType->getId())
+      ->execute());
 
     static::assertCount(
       0,
@@ -238,25 +264,38 @@ final class FundingCaseTypeTest extends AbstractFundingHeadlessTestCase {
       ->single()['file_type_id:name'];
     static::assertSame(FileTypeNames::TRANSFER_CONTRACT_TEMPLATE, $fileTypeName);
 
-    $attachment2 = AttachmentFixture::addFixture(
-      'civicrm_funding_case_type',
-      $fundingCaseType->getId(),
-      E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx')
-    );
+    $file2 = File::create(FALSE)
+      ->setValues([
+        'uri' => 'test',
+        'mime_type' => 'inode/x-empty',
+      ])->execute()->single();
 
-    // Previous file shall be deleted.
+    // New file shall be attached and the file type shall be set. Previous file shall be deleted.
     $result = FundingCaseType::update()
-      ->addValue('transfer_contract_template_file_id', $attachment2->getId())
+      ->addValue('transfer_contract_template_file_id', $file2['id'])
       ->addWhere('id', '=', $fundingCaseType->getId())
       ->execute();
-    static::assertSame($attachment2->getId(), $result->single()['transfer_contract_template_file_id']);
+    static::assertSame($file2['id'], $result->single()['transfer_contract_template_file_id']);
+
+    static::assertSame($file2['id'], FundingCaseType::get()
+      ->addSelect('transfer_contract_template_file_id')
+      ->addWhere('id', '=', $fundingCaseType->getId())
+      ->execute()->single()['transfer_contract_template_file_id']
+    );
 
     $fileTypeName = File::get(FALSE)
       ->addSelect('file_type_id:name')
-      ->addWhere('id', '=', $attachment2->getId())
+      ->addWhere('id', '=', $file2['id'])
       ->execute()
       ->single()['file_type_id:name'];
     static::assertSame(FileTypeNames::TRANSFER_CONTRACT_TEMPLATE, $fileTypeName);
+
+    static::assertCount(1, EntityFile::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('file_id', '=', $file2['id'])
+      ->addWhere('entity_table', '=', 'civicrm_funding_case_type')
+      ->addWhere('entity_id', '=', $fundingCaseType->getId())
+      ->execute());
 
     static::assertCount(
       0,
@@ -287,27 +326,40 @@ final class FundingCaseTypeTest extends AbstractFundingHeadlessTestCase {
       ->single()['file_type_id:name'];
     static::assertSame(FileTypeNames::PAYBACK_CLAIM_TEMPLATE, $fileTypeName);
 
-    $attachment2 = AttachmentFixture::addFixture(
-      'civicrm_funding_case_type',
-      $fundingCaseType->getId(),
-      E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx')
-    );
+    $file2 = File::create(FALSE)
+      ->setValues([
+        'uri' => 'test',
+        'mime_type' => 'inode/x-empty',
+      ])->execute()->single();
 
-    // Previous file shall be deleted.
+    // New file shall be attached and the file type shall be set. Previous file shall be deleted.
     $result = FundingCaseType::save()
       ->addRecord([
         'id' => $fundingCaseType->getId(),
-        'payback_claim_template_file_id' => $attachment2->getId(),
+        'payback_claim_template_file_id' => $file2['id'],
       ])
       ->execute();
-    static::assertSame($attachment2->getId(), $result->single()['payback_claim_template_file_id']);
+    static::assertSame($file2['id'], $result->single()['payback_claim_template_file_id']);
+
+    static::assertSame($file2['id'], FundingCaseType::get()
+      ->addSelect('payback_claim_template_file_id')
+      ->addWhere('id', '=', $fundingCaseType->getId())
+      ->execute()->single()['payback_claim_template_file_id']
+    );
 
     $fileTypeName = File::get(FALSE)
       ->addSelect('file_type_id:name')
-      ->addWhere('id', '=', $attachment2->getId())
+      ->addWhere('id', '=', $file2['id'])
       ->execute()
       ->single()['file_type_id:name'];
     static::assertSame(FileTypeNames::PAYBACK_CLAIM_TEMPLATE, $fileTypeName);
+
+    static::assertCount(1, EntityFile::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('file_id', '=', $file2['id'])
+      ->addWhere('entity_table', '=', 'civicrm_funding_case_type')
+      ->addWhere('entity_id', '=', $fundingCaseType->getId())
+      ->execute());
 
     static::assertCount(
       0,
@@ -338,27 +390,40 @@ final class FundingCaseTypeTest extends AbstractFundingHeadlessTestCase {
       ->single()['file_type_id:name'];
     static::assertSame(FileTypeNames::PAYMENT_INSTRUCTION_TEMPLATE, $fileTypeName);
 
-    $attachment2 = AttachmentFixture::addFixture(
-      'civicrm_funding_case_type',
-      $fundingCaseType->getId(),
-      E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx')
-    );
+    $file2 = File::create(FALSE)
+      ->setValues([
+        'uri' => 'test',
+        'mime_type' => 'inode/x-empty',
+      ])->execute()->single();
 
-    // Previous file shall be deleted.
+    // New file shall be attached and the file type shall be set. Previous file shall be deleted.
     $result = FundingCaseType::save()
       ->addRecord([
         'id' => $fundingCaseType->getId(),
-        'payment_instruction_template_file_id' => $attachment2->getId(),
+        'payment_instruction_template_file_id' => $file2['id'],
       ])
       ->execute();
-    static::assertSame($attachment2->getId(), $result->single()['payment_instruction_template_file_id']);
+    static::assertSame($file2['id'], $result->single()['payment_instruction_template_file_id']);
+
+    static::assertSame($file2['id'], FundingCaseType::get()
+      ->addSelect('payment_instruction_template_file_id')
+      ->addWhere('id', '=', $fundingCaseType->getId())
+      ->execute()->single()['payment_instruction_template_file_id']
+    );
 
     $fileTypeName = File::get(FALSE)
       ->addSelect('file_type_id:name')
-      ->addWhere('id', '=', $attachment2->getId())
+      ->addWhere('id', '=', $file2['id'])
       ->execute()
       ->single()['file_type_id:name'];
     static::assertSame(FileTypeNames::PAYMENT_INSTRUCTION_TEMPLATE, $fileTypeName);
+
+    static::assertCount(1, EntityFile::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('file_id', '=', $file2['id'])
+      ->addWhere('entity_table', '=', 'civicrm_funding_case_type')
+      ->addWhere('entity_id', '=', $fundingCaseType->getId())
+      ->execute());
 
     static::assertCount(
       0,
@@ -389,27 +454,40 @@ final class FundingCaseTypeTest extends AbstractFundingHeadlessTestCase {
       ->single()['file_type_id:name'];
     static::assertSame(FileTypeNames::TRANSFER_CONTRACT_TEMPLATE, $fileTypeName);
 
-    $attachment2 = AttachmentFixture::addFixture(
-      'civicrm_funding_case_type',
-      $fundingCaseType->getId(),
-      E::path('tests/phpunit/resources/FundingCaseDocumentTemplate.docx')
-    );
+    $file2 = File::create(FALSE)
+      ->setValues([
+        'uri' => 'test',
+        'mime_type' => 'inode/x-empty',
+      ])->execute()->single();
 
-    // Previous file shall be deleted.
+    // New file shall be attached and the file type shall be set. Previous file shall be deleted.
     $result = FundingCaseType::save()
       ->addRecord([
         'id' => $fundingCaseType->getId(),
-        'transfer_contract_template_file_id' => $attachment2->getId(),
+        'transfer_contract_template_file_id' => $file2['id'],
       ])
       ->execute();
-    static::assertSame($attachment2->getId(), $result->single()['transfer_contract_template_file_id']);
+    static::assertSame($file2['id'], $result->single()['transfer_contract_template_file_id']);
+
+    static::assertSame($file2['id'], FundingCaseType::get()
+      ->addSelect('transfer_contract_template_file_id')
+      ->addWhere('id', '=', $fundingCaseType->getId())
+      ->execute()->single()['transfer_contract_template_file_id']
+    );
 
     $fileTypeName = File::get(FALSE)
       ->addSelect('file_type_id:name')
-      ->addWhere('id', '=', $attachment2->getId())
+      ->addWhere('id', '=', $file2['id'])
       ->execute()
       ->single()['file_type_id:name'];
     static::assertSame(FileTypeNames::TRANSFER_CONTRACT_TEMPLATE, $fileTypeName);
+
+    static::assertCount(1, EntityFile::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('file_id', '=', $file2['id'])
+      ->addWhere('entity_table', '=', 'civicrm_funding_case_type')
+      ->addWhere('entity_id', '=', $fundingCaseType->getId())
+      ->execute());
 
     static::assertCount(
       0,

--- a/tests/phpunit/Civi/Funding/TestAttachmentManager.php
+++ b/tests/phpunit/Civi/Funding/TestAttachmentManager.php
@@ -34,6 +34,10 @@ final class TestAttachmentManager implements FundingAttachmentManagerInterface {
     $this->attachmentManager = $attachmentManager;
   }
 
+  public function attachById(int $id, string $entityTable, int $entityId): void {
+    $this->attachmentManager->attachById($id, $entityTable, $entityId);
+  }
+
   /**
    * @inheritDoc
    */


### PR DESCRIPTION
CiviCRM >=6.3 doesn't automatically connect files with entities via `EntityFile` anymore.

systopia-reference: 29804