### PR TITLE
Clearing process: Change to status `rework` on `request-change`

### DIFF
--- a/Civi/Funding/ClearingProcess/ClearingStatusDeterminer.php
+++ b/Civi/Funding/ClearingProcess/ClearingStatusDeterminer.php
@@ -54,11 +54,11 @@ class ClearingStatusDeterminer {
     ],
     'accepted' => [
       'review' => 'review',
-      'request-change' => 'draft',
+      'request-change' => 'rework',
     ],
     'rejected' => [
       'review' => 'review',
-      'request-change' => 'draft',
+      'request-change' => 'rework',
     ],
   ];
 


### PR DESCRIPTION
The status of a clearing process is changed from `accepted` and `rejected` to `rework` on `request-change` action. Previously the status `rework` was only set on `request-change` when in `review` status.

systopia-reference: 29867