### PR TITLE
Add clearing process status `rework-review-requested`

### DIFF
--- a/Civi/Funding/ClearingProcess/ClearingActionsDeterminer.php
+++ b/Civi/Funding/ClearingProcess/ClearingActionsDeterminer.php
@@ -62,6 +62,12 @@ class ClearingActionsDeterminer {
       ClearingProcessPermissions::REVIEW_CALCULATIVE => ['review', 'add-comment'],
       ClearingProcessPermissions::REVIEW_CONTENT => ['review', 'add-comment'],
     ],
+    'rework-review-requested' => [
+      ClearingProcessPermissions::CLEARING_APPLY => ['modify'],
+      ClearingProcessPermissions::CLEARING_MODIFY => ['modify'],
+      ClearingProcessPermissions::REVIEW_CALCULATIVE => ['review', 'add-comment'],
+      ClearingProcessPermissions::REVIEW_CONTENT => ['review', 'add-comment'],
+    ],
     'accepted' => [
       ClearingProcessPermissions::CLEARING_APPLY => [],
       ClearingProcessPermissions::CLEARING_MODIFY => [],

--- a/Civi/Funding/ClearingProcess/ClearingStatusDeterminer.php
+++ b/Civi/Funding/ClearingProcess/ClearingStatusDeterminer.php
@@ -49,7 +49,11 @@ class ClearingStatusDeterminer {
     ],
     'rework' => [
       'save' => 'rework',
-      'apply' => 'review-requested',
+      'apply' => 'rework-review-requested',
+      'review' => 'review',
+    ],
+    'rework-review-requested' => [
+      'modify' => 'rework',
       'review' => 'review',
     ],
     'accepted' => [

--- a/Civi/Funding/FundingPseudoConstants.php
+++ b/Civi/Funding/FundingPseudoConstants.php
@@ -164,6 +164,15 @@ final class FundingPseudoConstants {
         'description' => NULL,
       ],
       [
+        'id' => 'rework-review-requested',
+        'name' => 'rework-review-requested',
+        'label' => E::ts('Rework review requested'),
+        'icon' => 'fa-circle-o',
+        'color' => NULL,
+        'abbr' => NULL,
+        'description' => NULL,
+      ],
+      [
         'id' => 'accepted',
         'name' => 'accepted',
         'label' => E::ts('Accepted'),

--- a/l10n/de_DE/LC_MESSAGES/funding.po
+++ b/l10n/de_DE/LC_MESSAGES/funding.po
@@ -1511,6 +1511,7 @@ msgid "Rework requested"
 msgstr "Überarbeitung beantragt"
 
 #: Civi/Funding/FundingCaseType/MetaData/ReworkApplicationProcessStatuses.php
+#: Civi/Funding/FundingPseudoConstants.php
 msgid "Rework review requested"
 msgstr "Prüfung der Überarbeitung beantragt"
 

--- a/l10n/funding.pot
+++ b/l10n/funding.pot
@@ -1034,7 +1034,7 @@ msgstr ""
 msgid "Rework requested"
 msgstr ""
 
-#: Civi/Funding/FundingCaseType/MetaData/ReworkApplicationProcessStatuses.php
+#: Civi/Funding/FundingCaseType/MetaData/ReworkApplicationProcessStatuses.php Civi/Funding/FundingPseudoConstants.php
 msgid "Rework review requested"
 msgstr ""
 


### PR DESCRIPTION
When a a clearing process in status `rework` is applied it's new status is now `rework-review-requested` instead of `review-requested`. This makes it impossible to reach the status `draft` again.

systopia-reference: 29867