### PR TITLE
Switch action menu to action link section in SearchKit result lists 

### DIFF
--- a/managed/SavedSearch_Clearings.mgd.php
+++ b/managed/SavedSearch_Clearings.mgd.php
@@ -205,14 +205,11 @@ return [
               ],
             ],
             [
-              'text' => '',
-              'style' => 'default',
-              'size' => 'btn-sm',
-              'icon' => 'fa-bars',
+              'size' => 'btn-xs',
               'links' => [
                 [
                   'path' => 'civicrm/a/#/funding/clearing/[id]',
-                  'icon' => 'fa-folder-open-o',
+                  'icon' => 'fa-folder-open',
                   'text' => E::ts('Open clearing'),
                   'style' => 'default',
                   'condition' => [
@@ -228,7 +225,7 @@ return [
                 ],
                 [
                   'path' => 'civicrm/a/#/funding/application/[application_process_id]',
-                  'icon' => 'fa-folder-open-o',
+                  'icon' => 'fa-folder-open',
                   'text' => E::ts('Open application'),
                   'style' => 'default',
                   'condition' => [],
@@ -240,7 +237,7 @@ return [
                 ],
                 [
                   'path' => 'civicrm/a/#/funding/case/[FundingClearingProcess_FundingApplicationProcess_application_process_id_01.funding_case_id]/permissions',
-                  'icon' => 'fa-pencil-square-o',
+                  'icon' => 'fa-pen-to-square',
                   'text' => E::ts('Edit permissions'),
                   'style' => 'default',
                   'condition' => [],
@@ -251,7 +248,7 @@ return [
                   'target' => '',
                 ],
               ],
-              'type' => 'menu',
+              'type' => 'buttons',
               'alignment' => 'text-right',
               'label' => E::ts('Actions'),
             ],

--- a/managed/SavedSearch_funding_application_processes.mgd.php
+++ b/managed/SavedSearch_funding_application_processes.mgd.php
@@ -155,14 +155,11 @@ return [
               ],
             ],
             [
-              'text' => E::ts('Actions'),
-              'style' => 'default',
               'size' => 'btn-xs',
-              'icon' => 'fa-bars',
               'links' => [
                 [
                   'path' => 'civicrm/a#/funding/application/[id]',
-                  'icon' => 'fa-folder-open-o',
+                  'icon' => 'fa-folder-open',
                   'text' => E::ts('Open application'),
                   'style' => 'default',
                   'condition' => [],
@@ -174,7 +171,7 @@ return [
                 ],
                 [
                   'path' => 'civicrm/a#/funding/clearing/[FundingApplicationProcess_FundingClearingProcess_application_process_id_01.id]',
-                  'icon' => 'fa-folder-open-o',
+                  'icon' => 'fa-folder-open',
                   'text' => E::ts('Open clearing'),
                   'style' => 'default',
                   'condition' => [
@@ -189,9 +186,9 @@ return [
                   'target' => '',
                 ],
               ],
-              'type' => 'menu',
+              'type' => 'buttons',
               'alignment' => 'text-right',
-              'label' => '',
+              'label' => E::ts('Actions'),
             ],
           ],
           'actions' => [

--- a/managed/SavedSearch_funding_case_application_processes.mgd.php
+++ b/managed/SavedSearch_funding_case_application_processes.mgd.php
@@ -172,14 +172,11 @@ return [
               'sortable' => TRUE,
             ],
             [
-              'text' => E::ts('Actions'),
-              'style' => 'default',
-              'size' => 'btn-sm',
-              'icon' => 'fa-bars',
+              'size' => 'btn-xs',
               'links' => [
                 [
                   'path' => 'civicrm/a/#/funding/application/[id]',
-                  'icon' => 'fa-folder-open-o',
+                  'icon' => 'fa-folder-open',
                   'text' => E::ts('Open application'),
                   'style' => 'default',
                   'condition' => [],
@@ -191,7 +188,7 @@ return [
                 ],
                 [
                   'path' => 'civicrm/a/#/funding/clearing/[FundingApplicationProcess_FundingClearingProcess_application_process_id_01.id]',
-                  'icon' => 'fa-external-link',
+                  'icon' => 'fa-folder-open',
                   'text' => E::ts('Open clearing'),
                   'style' => 'default',
                   'condition' => [
@@ -207,7 +204,7 @@ return [
                 ],
                 [
                   'path' => 'civicrm/a/#/funding/case/[funding_case_id]/permissions',
-                  'icon' => 'fa-pencil-square-o',
+                  'icon' => 'fa-pen-to-square',
                   'text' => E::ts('Edit permissions'),
                   'style' => 'default',
                   'condition' => [
@@ -224,8 +221,9 @@ return [
                   'task' => '',
                 ],
               ],
-              'type' => 'menu',
+              'type' => 'buttons',
               'alignment' => 'text-right',
+              'label' => E::ts('Actions'),
             ],
           ],
           'actions' => [

--- a/managed/SavedSearch_funding_cases.mgd.php
+++ b/managed/SavedSearch_funding_cases.mgd.php
@@ -219,14 +219,11 @@ return [
               ],
             ],
             [
-              'text' => E::ts('Actions'),
-              'style' => 'default',
-              'size' => 'btn-sm',
-              'icon' => 'fa-bars',
+              'size' => 'btn-xs',
               'links' => [
                 [
                   'path' => 'civicrm/a#funding/case/[id]',
-                  'icon' => 'fa-folder-open-o',
+                  'icon' => 'fa-folder-open',
                   'text' => E::ts('Open case'),
                   'style' => 'default',
                   'condition' => [],
@@ -238,7 +235,7 @@ return [
                 ],
                 [
                   'path' => 'civicrm/a/#/funding/case/[id]/permissions',
-                  'icon' => 'fa-pencil-square-o',
+                  'icon' => 'fa-pen-to-square',
                   'text' => E::ts('Edit permissions'),
                   'style' => 'default',
                   'condition' => [
@@ -253,8 +250,9 @@ return [
                   'task' => '',
                 ],
               ],
-              'type' => 'menu',
+              'type' => 'buttons',
               'alignment' => 'text-right',
+              'label' => E::ts('Actions'),
             ],
           ],
           'actions' => [


### PR DESCRIPTION
systopia-reference: #29469

This PR contains a new Button Section In the SearchKit result table. This sections replaces the former Action-Menu by directly displaying all Action-Links without hiding them in a drop-down menu.

This affects the Search-Kits:

Verwendungsnachweise
- SavedSearch_Clearings.mgd.php

Förderanträge
- SavedSearch_funding_application_processes.mgd.php
- SavedSearchFundingApplicationProcesses.mgd.php

Förderfallanträge
  - SavedSearch_funding_case_application_processes.mgd.php

Förderfälle
-  SavedSearch_funding_cases.mgd.php