### PR TITLE
Ensure compatibility with older MariaDB versions

### DIFF
--- a/sql/upgrade/0016.sql
+++ b/sql/upgrade/0016.sql
@@ -1,2 +1,2 @@
-ALTER TABLE civicrm_funding_clearing_cost_item RENAME COLUMN recipient TO payment_party;
-ALTER TABLE civicrm_funding_clearing_resources_item RENAME COLUMN recipient TO payment_party;
+ALTER TABLE civicrm_funding_clearing_cost_item CHANGE recipient payment_party varchar(255);
+ALTER TABLE civicrm_funding_clearing_resources_item CHANGE recipient payment_party varchar(255);


### PR DESCRIPTION
`ALTER TABLE t RENAME COLUMN` is not available in MariaDB <10.5.3.