### PR TITLE
Use string literal in ts

### DIFF
--- a/Civi/Funding/Contact/Relation/Types/ContactTypeAndGroup.php
+++ b/Civi/Funding/Contact/Relation/Types/ContactTypeAndGroup.php
@@ -69,9 +69,7 @@ TEMPLATE;
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-Contacts with any of the specified types in any of the specified groups.
-HELP);
+    return E::ts('Contacts with any of the specified types in any of the specified groups.');
   }
 
   /**

--- a/Civi/Funding/Contact/Relation/Types/Relationship.php
+++ b/Civi/Funding/Contact/Relation/Types/Relationship.php
@@ -81,12 +81,7 @@ TEMPLATE;
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-Contacts to which a relationship exists are available as recipients. The
-relationship type may be limited to various types. The type of the related
-contacts may be limited to various types. The related contacts may be limited to
-those in any of the given groups.
-HELP);
+    return E::ts('Contacts to which a relationship exists are available as recipients. The relationship type may be limited to various types. The type of the related contacts may be limited to various types. The related contacts may be limited to those in any of the given groups.');
   }
 
   /**

--- a/Civi/Funding/Contact/Relation/Types/SelfByContactType.php
+++ b/Civi/Funding/Contact/Relation/Types/SelfByContactType.php
@@ -51,10 +51,7 @@ TEMPLATE;
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-The applying contact itself is available as recipient if the contact is of the
-specified type.
-HELP);
+    return E::ts('The applying contact itself is available as recipient if the contact is of the specified type.');
   }
 
   public function getExtra(): array {

--- a/Civi/Funding/Permission/ContactRelation/Types/Contact.php
+++ b/Civi/Funding/Permission/ContactRelation/Types/Contact.php
@@ -44,9 +44,7 @@ TEMPLATE;
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-Matches if a contact is equal to the specified one.
-HELP);
+    return E::ts('Matches if a contact is equal to the specified one.');
   }
 
   public function getExtra(): array {

--- a/Civi/Funding/Permission/ContactRelation/Types/ContactRelationships.php
+++ b/Civi/Funding/Permission/ContactRelation/Types/ContactRelationships.php
@@ -75,9 +75,7 @@ TEMPLATE;
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-Matches if a contact has all specified relationships.
-HELP);
+    return E::ts("Matches if a contact has all specified relationships.");
   }
 
   public function getExtra(): array {

--- a/Civi/Funding/Permission/ContactRelation/Types/ContactTypeAndGroup.php
+++ b/Civi/Funding/Permission/ContactRelation/Types/ContactTypeAndGroup.php
@@ -68,10 +68,7 @@ TEMPLATE;
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-Matches if a contact has one of the specified contact types and is in one of the
-specified groups.
-HELP);
+    return E::ts("Matches if a contact has one of the specified contact types and is in one of the specified groups.");
   }
 
   /**

--- a/Civi/Funding/Permission/ContactRelation/Types/Relationship.php
+++ b/Civi/Funding/Permission/ContactRelation/Types/Relationship.php
@@ -81,11 +81,7 @@ TEMPLATE;
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-Matches a contact that has a relationship. The relationship type may be limited
-to various types. The type of the related contacts may be limited to various
-types. The related contacts may be limited to those in any of the given groups.
-HELP);
+    return E::ts("Matches a contact that has a relationship. The relationship type may be limited to various types. The type of the related contacts may be limited to various types. The related contacts may be limited to those in any of the given groups.");
   }
 
   /**

--- a/Civi/Funding/Permission/FundingCase/RelationFactory/Types/Contact.php
+++ b/Civi/Funding/Permission/FundingCase/RelationFactory/Types/Contact.php
@@ -47,9 +47,7 @@ TEMPLATE;
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-Assign permissions for new funding cases to the specified contact.
-HELP);
+    return E::ts("Assign permissions for new funding cases to the specified contact.");
   }
 
   public function getExtra(): array {

--- a/Civi/Funding/Permission/FundingCase/RelationFactory/Types/ContactTypeAndGroup.php
+++ b/Civi/Funding/Permission/FundingCase/RelationFactory/Types/ContactTypeAndGroup.php
@@ -71,10 +71,7 @@ TEMPLATE;
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-Assign permissions for new funding cases to contacts with one of the specified
-contact types in one of the specified groups.
-HELP);
+    return E::ts("Assign permissions for new funding cases to contacts with one of the specified contact types in one of the specified groups.");
   }
 
   /**

--- a/Civi/Funding/Permission/FundingCase/RelationFactory/Types/CreationAndRecipientContactRelationship.php
+++ b/Civi/Funding/Permission/FundingCase/RelationFactory/Types/CreationAndRecipientContactRelationship.php
@@ -60,11 +60,7 @@ TEMPLATE;
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-Assign permissions for new funding cases to contacts that have a relationship
-of the specified type to the creation contact and a relationship of the
-specified type to the recipient contact.
-HELP);
+    return E::ts("Assign permissions for new funding cases to contacts that have a relationship of the specified type to the creation contact and a relationship of the specified type to the recipient contact.");
   }
 
   public function getExtra(): array {

--- a/Civi/Funding/Permission/FundingCase/RelationFactory/Types/CreationContact.php
+++ b/Civi/Funding/Permission/FundingCase/RelationFactory/Types/CreationContact.php
@@ -42,9 +42,7 @@ final class CreationContact extends AbstractRelationPropertiesFactoryType {
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-Assign permissions for new funding cases to the contact which created the funding case.
-HELP);
+    return E::ts('Assign permissions for new funding cases to the contact which created the funding case.');
   }
 
   public function getExtra(): array {

--- a/Civi/Funding/Permission/FundingCase/RelationFactory/Types/CreationContactRelationship.php
+++ b/Civi/Funding/Permission/FundingCase/RelationFactory/Types/CreationContactRelationship.php
@@ -56,10 +56,7 @@ TEMPLATE;
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-Assign permissions for new funding cases to contacts that have a relationship
-of the specified type to the creation contact.
-HELP);
+    return E::ts("Assign permissions for new funding cases to contacts that have a relationship of the specified type to the creation contact.");
   }
 
   public function getExtra(): array {

--- a/Civi/Funding/Permission/FundingCase/RelationFactory/Types/RecipientContactRelationship.php
+++ b/Civi/Funding/Permission/FundingCase/RelationFactory/Types/RecipientContactRelationship.php
@@ -56,10 +56,7 @@ TEMPLATE;
   }
 
   public function getHelp(): string {
-    return E::ts(<<<HELP
-Assign permissions for new funding cases to contacts that have a relationship
-of the specified type to the recipient contact.
-HELP);
+    return E::ts('Assign permissions for new funding cases to contacts that have a relationship of the specified type to the recipient contact.');
   }
 
   public function getExtra(): array {


### PR DESCRIPTION
Our translation system can't cope with anything but string literals.

See https://docs.civicrm.org/dev/en/latest/translation/#best-practices