### PR TITLE
MoneyFactory: Replace deprecated code

### DIFF
--- a/Civi/Funding/Util/MoneyFactory.php
+++ b/Civi/Funding/Util/MoneyFactory.php
@@ -34,7 +34,7 @@ final class MoneyFactory {
   public function createMoney(float $amount, ?string $currencyCode): Money {
     $currency = $this->getCurrencyObject($currencyCode ?? $this->getDefaultCurrencyCode());
 
-    return Money::of($amount, $currency, NULL, RoundingMode::HALF_UP);
+    return Money::of($amount, $currency, NULL, RoundingMode::HalfUp);
   }
 
   /**

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "psr/simple-cache": "^1 || ^2 || ^3",
         "symfony/http-foundation": " ^5.4 || ^6 || ^7",
         "symfony/http-kernel": " ^5.4 || ^6 || ^7",
@@ -28,6 +28,9 @@
     },
     "require-dev": {
         "colinodell/psr-testlogger": "^1"
+    },
+    "conflict": {
+      "brick/math": "<0.14.2"
     },
     "autoload-dev": {
         "psr-4": { "Civi\\": "tests/phpunit/Civi/" }


### PR DESCRIPTION
This makes use of the camel case enum `\Brick\Math\RoundingMode::HalfUp` which depends on brick/math >=0.14.2. This increases the minimum PHP version to 8.2. Therefore merging this PR is deferred.