### PR TITLE
 Personalkosten: Update application on restore if Foerderquote or Sachkostenpauschale changed

### DIFF
--- a/Civi/Funding/ApplicationProcess/Snapshot/ApplicationSnapshotRestorer.php
+++ b/Civi/Funding/ApplicationProcess/Snapshot/ApplicationSnapshotRestorer.php
@@ -19,6 +19,7 @@ declare(strict_types = 1);
 
 namespace Civi\Funding\ApplicationProcess\Snapshot;
 
+use Civi\Core\CiviEventDispatcherInterface;
 use Civi\Funding\ApplicationProcess\ApplicationCostItemManager;
 use Civi\Funding\ApplicationProcess\ApplicationExternalFileManagerInterface;
 use Civi\Funding\ApplicationProcess\ApplicationProcessManager;
@@ -28,6 +29,7 @@ use Civi\Funding\Entity\ApplicationCostItemEntity;
 use Civi\Funding\Entity\ApplicationProcessEntityBundle;
 use Civi\Funding\Entity\ApplicationResourcesItemEntity;
 use Civi\Funding\Entity\ApplicationSnapshotEntity;
+use Civi\Funding\Event\ApplicationProcess\ApplicationSnapshotRestoredEvent;
 use Webmozart\Assert\Assert;
 
 final class ApplicationSnapshotRestorer implements ApplicationSnapshotRestorerInterface {
@@ -38,6 +40,8 @@ final class ApplicationSnapshotRestorer implements ApplicationSnapshotRestorerIn
 
   private ApplicationCostItemManager $costItemManager;
 
+  private CiviEventDispatcherInterface $eventDispatcher;
+
   private ApplicationExternalFileManagerInterface $externalFileManager;
 
   private ApplicationResourcesItemManager $resourcesItemManager;
@@ -46,12 +50,14 @@ final class ApplicationSnapshotRestorer implements ApplicationSnapshotRestorerIn
     ApplicationProcessManager $applicationProcessManager,
     ApplicationSnapshotManager $applicationSnapshotManager,
     ApplicationCostItemManager $costItemManager,
+    CiviEventDispatcherInterface $eventDispatcher,
     ApplicationExternalFileManagerInterface $externalFileManager,
     ApplicationResourcesItemManager $resourcesItemManager
   ) {
     $this->applicationProcessManager = $applicationProcessManager;
     $this->applicationSnapshotManager = $applicationSnapshotManager;
     $this->costItemManager = $costItemManager;
+    $this->eventDispatcher = $eventDispatcher;
     $this->externalFileManager = $externalFileManager;
     $this->resourcesItemManager = $resourcesItemManager;
   }
@@ -98,6 +104,11 @@ final class ApplicationSnapshotRestorer implements ApplicationSnapshotRestorerIn
     }
 
     $this->externalFileManager->deleteFiles($applicationProcess->getId(), $usedIdentifiers);
+
+    $this->eventDispatcher->dispatch(
+      ApplicationSnapshotRestoredEvent::class,
+      new ApplicationSnapshotRestoredEvent($applicationProcessBundle),
+    );
   }
 
   /**

--- a/Civi/Funding/Event/ApplicationProcess/ApplicationSnapshotRestoredEvent.php
+++ b/Civi/Funding/Event/ApplicationProcess/ApplicationSnapshotRestoredEvent.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Copyright (C) 2022 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Funding\Event\ApplicationProcess;
+
+use Civi\Funding\Entity\ApplicationProcessEntityBundle;
+use Civi\Funding\Entity\ApplicationSnapshotEntity;
+
+class ApplicationSnapshotRestoredEvent extends AbstractApplicationEvent {
+
+  public function __construct(
+    ApplicationProcessEntityBundle $applicationProcessBundle
+  ) {
+    parent::__construct($applicationProcessBundle);
+  }
+
+  public function getSnapshot(): ApplicationSnapshotEntity {
+    /** @var \Civi\Funding\Entity\ApplicationSnapshotEntity */
+    return $this->applicationProcessBundle->getApplicationProcess()->getRestoredSnapshot();
+  }
+
+}

--- a/Civi/Funding/FundingCaseTypes/AuL/Personalkosten/Application/JsonSchema/PersonalkostenApplicationJsonSchemaFactory.php
+++ b/Civi/Funding/FundingCaseTypes/AuL/Personalkosten/Application/JsonSchema/PersonalkostenApplicationJsonSchemaFactory.php
@@ -27,25 +27,20 @@ use Civi\Funding\Entity\FundingCaseTypeEntity;
 use Civi\Funding\Entity\FundingProgramEntity;
 use Civi\Funding\Form\Application\NonCombinedApplicationJsonSchemaFactoryInterface;
 use Civi\Funding\FundingCaseTypes\AuL\Personalkosten\Traits\PersonalkostenSupportedFundingCaseTypesTrait;
-use Civi\RemoteTools\Api4\Api4Interface;
 use Civi\RemoteTools\JsonSchema\JsonSchema;
 
 final class PersonalkostenApplicationJsonSchemaFactory implements NonCombinedApplicationJsonSchemaFactoryInterface {
 
   use PersonalkostenSupportedFundingCaseTypesTrait;
 
-  private Api4Interface $api4;
-
   private FundingCaseRecipientLoaderInterface $existingCaseRecipientLoader;
 
   private PossibleRecipientsLoaderInterface $possibleRecipientsLoader;
 
   public function __construct(
-    Api4Interface $api4,
     FundingCaseRecipientLoaderInterface $existingCaseRecipientLoader,
     PossibleRecipientsLoaderInterface $possibleRecipientsLoader
   ) {
-    $this->api4 = $api4;
     $this->existingCaseRecipientLoader = $existingCaseRecipientLoader;
     $this->possibleRecipientsLoader = $possibleRecipientsLoader;
   }
@@ -60,11 +55,11 @@ final class PersonalkostenApplicationJsonSchemaFactory implements NonCombinedApp
     $fundingCase = $applicationProcessBundle->getFundingCase();
     $fundingProgram = $applicationProcessBundle->getFundingProgram();
 
-    [$foerderquote, $sachkostenpauschale] = $this->getFoerderquoteAndSachkostenpauschale($fundingProgram->getId());
-
     return new PersonalkostenApplicationJsonSchema(
-      $foerderquote,
-      $sachkostenpauschale,
+    // @phpstan-ignore argument.type
+      $fundingProgram->get('funding_program_extra.foerderquote'),
+      // @phpstan-ignore argument.type
+      $fundingProgram->get('funding_program_extra.sachkostenpauschale'),
       $fundingProgram->getStartDate(),
       $fundingProgram->getEndDate(),
       $this->existingCaseRecipientLoader->getRecipient($fundingCase),
@@ -80,11 +75,11 @@ final class PersonalkostenApplicationJsonSchemaFactory implements NonCombinedApp
     FundingCaseTypeEntity $fundingCaseType,
     FundingProgramEntity $fundingProgram
   ): JsonSchema {
-    [$foerderquote, $sachkostenpauschale] = $this->getFoerderquoteAndSachkostenpauschale($fundingProgram->getId());
-
     return new PersonalkostenApplicationJsonSchema(
-      $foerderquote,
-      $sachkostenpauschale,
+      // @phpstan-ignore argument.type
+      $fundingProgram->get('funding_program_extra.foerderquote'),
+      // @phpstan-ignore argument.type
+      $fundingProgram->get('funding_program_extra.sachkostenpauschale'),
       $fundingProgram->getStartDate(),
       $fundingProgram->getEndDate(),
       $this->possibleRecipientsLoader->getPossibleRecipients($contactId, $fundingProgram),
@@ -107,26 +102,6 @@ final class PersonalkostenApplicationJsonSchemaFactory implements NonCombinedApp
       [],
       [],
     );
-  }
-
-  /**
-   * @return array{int, float}
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function getFoerderquoteAndSachkostenpauschale(int $fundingProgramId): array {
-    $values = $this->api4->execute('FundingProgram', 'get', [
-      'select' => [
-        'funding_program_extra.foerderquote',
-        'funding_program_extra.sachkostenpauschale',
-      ],
-      'where' => [['id', '=', $fundingProgramId]],
-    ])->single();
-
-    return [
-      $values['funding_program_extra.foerderquote'],
-      $values['funding_program_extra.sachkostenpauschale'],
-    ];
   }
 
   /**

--- a/Civi/Funding/FundingCaseTypes/AuL/Personalkosten/Application/PersonalkostenApplicationProcessUpdater.php
+++ b/Civi/Funding/FundingCaseTypes/AuL/Personalkosten/Application/PersonalkostenApplicationProcessUpdater.php
@@ -27,7 +27,7 @@ use Civi\Funding\ApplicationProcess\Handler\ApplicationFormSubmitHandlerInterfac
 use Civi\Funding\ClearingProcess\ClearingCostItemManager;
 use Civi\Funding\Entity\ApplicationProcessEntityBundle;
 
-final class PersonalkostenApplicationProcessUpdater {
+class PersonalkostenApplicationProcessUpdater {
 
   private ApplicationCostItemManager $applicationCostItemManager;
 

--- a/Civi/Funding/FundingCaseTypes/AuL/Personalkosten/EventSubscriber/PersonalkostenSnapshotRestoreSubscriber.php
+++ b/Civi/Funding/FundingCaseTypes/AuL/Personalkosten/EventSubscriber/PersonalkostenSnapshotRestoreSubscriber.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Funding\FundingCaseTypes\AuL\Personalkosten\EventSubscriber;
+
+use Civi\Funding\Event\ApplicationProcess\ApplicationSnapshotRestoredEvent;
+use Civi\Funding\FundingCaseTypes\AuL\Personalkosten\Application\PersonalkostenApplicationProcessUpdater;
+use Civi\Funding\FundingCaseTypes\AuL\Personalkosten\PersonalkostenMetaData;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class PersonalkostenSnapshotRestoreSubscriber implements EventSubscriberInterface {
+
+  private PersonalkostenApplicationProcessUpdater $personalkostenApplicationProcessUpdater;
+
+  /**
+   * @inheritDoc
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      ApplicationSnapshotRestoredEvent::class => 'onRestored',
+    ];
+  }
+
+  public function __construct(PersonalkostenApplicationProcessUpdater $personalkostenApplicationProcessUpdater) {
+    $this->personalkostenApplicationProcessUpdater = $personalkostenApplicationProcessUpdater;
+  }
+
+  public function onRestored(ApplicationSnapshotRestoredEvent $event): void {
+    if ($event->getFundingCaseType()->getName() !== PersonalkostenMetaData::NAME) {
+      return;
+    }
+
+    $fundingProgram = $event->getFundingProgram();
+    /** @var int $foerderquote */
+    $foerderquote = $fundingProgram->get('funding_program_extra.foerderquote');
+    /** @var float $sachkostenpauschale */
+    $sachkostenpauschale = $fundingProgram->get('funding_program_extra.sachkostenpauschale');
+
+    $restoredRequestData = $event->getApplicationProcess()->getRequestData();
+    $restoredFoerderquote = $restoredRequestData['foerderquote'];
+    // @phpstan-ignore cast.double
+    $restoredSachkostenpauschale = (float) $restoredRequestData['sachkostenpauschale'];
+
+    if ($foerderquote !== $restoredFoerderquote || $sachkostenpauschale !== $restoredSachkostenpauschale) {
+      $this->personalkostenApplicationProcessUpdater->updateApplicationProcess(
+        $event->getApplicationProcessBundle(),
+        $foerderquote,
+        $sachkostenpauschale,
+      );
+    }
+  }
+
+}

--- a/Civi/Funding/FundingProgram/FundingProgramManager.php
+++ b/Civi/Funding/FundingProgram/FundingProgramManager.php
@@ -54,7 +54,8 @@ class FundingProgramManager {
     if (!array_key_exists($id, $this->fundingPrograms)) {
       $action = FundingProgram::get(FALSE)
         ->setAllowEmptyRecordPermissions(TRUE)
-        ->addWhere('id', '=', $id);
+        ->addWhere('id', '=', $id)
+        ->addSelect('*', 'custom.*');
       $result = $this->api4->executeAction($action);
       $this->fundingPrograms[$id] = FundingProgramEntity::singleOrNullFromApiResult($result);
     }

--- a/tests/phpunit/Civi/Funding/ApplicationProcess/Snapshot/ApplicationSnapshotRestorerTest.php
+++ b/tests/phpunit/Civi/Funding/ApplicationProcess/Snapshot/ApplicationSnapshotRestorerTest.php
@@ -19,6 +19,7 @@ declare(strict_types = 1);
 
 namespace Civi\Funding\ApplicationProcess\Snapshot;
 
+use Civi\Core\CiviEventDispatcherInterface;
 use Civi\Funding\ApplicationProcess\ApplicationCostItemManager;
 use Civi\Funding\ApplicationProcess\ApplicationExternalFileManagerInterface;
 use Civi\Funding\ApplicationProcess\ApplicationProcessManager;
@@ -29,6 +30,7 @@ use Civi\Funding\EntityFactory\ApplicationProcessBundleFactory;
 use Civi\Funding\EntityFactory\ApplicationResourcesItemFactory;
 use Civi\Funding\EntityFactory\ApplicationSnapshotFactory;
 use Civi\Funding\EntityFactory\ExternalFileFactory;
+use Civi\Funding\Event\ApplicationProcess\ApplicationSnapshotRestoredEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -37,44 +39,33 @@ use PHPUnit\Framework\TestCase;
  */
 final class ApplicationSnapshotRestorerTest extends TestCase {
 
-  /**
-   * @var \Civi\Funding\ApplicationProcess\ApplicationProcessManager&\PHPUnit\Framework\MockObject\MockObject
-   */
-  private MockObject $applicationProcessManagerMock;
+  private ApplicationProcessManager&MockObject $applicationProcessManagerMock;
 
-  /**
-   * @var \Civi\Funding\ApplicationProcess\ApplicationSnapshotManager&\PHPUnit\Framework\MockObject\MockObject
-   */
-  private MockObject $applicationSnapshotManagerMock;
+  private ApplicationSnapshotManager&MockObject $applicationSnapshotManagerMock;
 
   private ApplicationSnapshotRestorer $applicationSnapshotRestorer;
 
-  /**
-   * @var \Civi\Funding\ApplicationProcess\ApplicationCostItemManager&\PHPUnit\Framework\MockObject\MockObject
-   */
-  private MockObject $costItemManagerMock;
+  private ApplicationCostItemManager&MockObject $costItemManagerMock;
 
-  /**
-   * @var \Civi\Funding\ApplicationProcess\ApplicationExternalFileManagerInterface&\PHPUnit\Framework\MockObject\MockObject
-   */
-  private MockObject $externalFileManagerMock;
+  private CiviEventDispatcherInterface&MockObject $eventDispatcherMock;
 
-  /**
-   * @var \Civi\Funding\ApplicationProcess\ApplicationResourcesItemManager&\PHPUnit\Framework\MockObject\MockObject
-   */
-  private MockObject $resourcesItemManagerMock;
+  private ApplicationExternalFileManagerInterface&MockObject $externalFileManagerMock;
+
+  private ApplicationResourcesItemManager&MockObject $resourcesItemManagerMock;
 
   protected function setUp(): void {
     parent::setUp();
     $this->applicationProcessManagerMock = $this->createMock(ApplicationProcessManager::class);
     $this->applicationSnapshotManagerMock = $this->createMock(ApplicationSnapshotManager::class);
     $this->costItemManagerMock = $this->createMock(ApplicationCostItemManager::class);
+    $this->eventDispatcherMock = $this->createMock(CiviEventDispatcherInterface::class);
     $this->externalFileManagerMock = $this->createMock(ApplicationExternalFileManagerInterface::class);
     $this->resourcesItemManagerMock = $this->createMock(ApplicationResourcesItemManager::class);
     $this->applicationSnapshotRestorer = new ApplicationSnapshotRestorer(
       $this->applicationProcessManagerMock,
       $this->applicationSnapshotManagerMock,
       $this->costItemManagerMock,
+      $this->eventDispatcherMock,
       $this->externalFileManagerMock,
       $this->resourcesItemManagerMock
     );
@@ -114,6 +105,12 @@ final class ApplicationSnapshotRestorerTest extends TestCase {
       ->with($externalFile);
     $this->externalFileManagerMock->expects(static::once())->method('deleteFiles')
       ->with($applicationProcess->getId(), ['testIdentifier']);
+
+    $this->eventDispatcherMock->expects(static::once())->method('dispatch')
+      ->with(
+        ApplicationSnapshotRestoredEvent::class,
+        new ApplicationSnapshotRestoredEvent($applicationProcessBundle),
+      );
 
     $this->applicationSnapshotRestorer->restoreLastSnapshot($applicationProcessBundle);
 


### PR DESCRIPTION
If an application snaphost is restored and the Förderquote or Sachkostenpauschale was changed after the snapshot was created the dependent values have to be re-calculated.

systopia-reference: 32311