### PR TITLE
Perform `RemoteFundingClearingProcess.getOrCreate` in transaction

### DIFF
--- a/Civi/Funding/EventSubscriber/Api/TransactionalApiRequestSubscriber.php
+++ b/Civi/Funding/EventSubscriber/Api/TransactionalApiRequestSubscriber.php
@@ -26,7 +26,8 @@ final class TransactionalApiRequestSubscriber extends AbstractTransactionalApiRe
 
   protected function isTransactionalAction(string $entity, string $action): bool {
     return (str_starts_with($entity, 'Funding') || str_starts_with($entity, 'RemoteFunding'))
-      && !str_starts_with($action, 'get');
+      // RemoteFundingClearingProcess has getOrCreate action.
+      && (!str_starts_with($action, 'get') || $action === 'getOrCreate');
   }
 
 }


### PR DESCRIPTION
Previously the `RemoteFundingClearingProcess.getOrCreate` action failed because it is tried to add a pre-commit callback in `\Civi\Funding\EventSubscriber\FundingCase\UpdateAmountApprovedOnAmountEligibleChangeSubscriber` and `\Civi\Funding\EventSubscriber\FundingCase\UpdateAmountApprovedSumOfAmountsEligibleSubscriber` without a transaction being running.