### PR TITLE
Allow mapped data in clearing forms

### DIFF
--- a/CRM/Funding/Upgrader.php
+++ b/CRM/Funding/Upgrader.php
@@ -30,6 +30,7 @@ use Civi\Funding\Upgrade\Upgrader0013;
 use Civi\Funding\Upgrade\Upgrader0014;
 use Civi\Funding\Upgrade\Upgrader0017;
 use Civi\Funding\Upgrade\Upgrader0020;
+use Civi\Funding\Upgrade\Upgrader0021;
 use CRM_Funding_ExtensionUtil as E;
 
 /**
@@ -231,6 +232,14 @@ final class CRM_Funding_Upgrader extends CRM_Extension_Upgrader_Base {
 
     /** @var \Civi\Funding\Upgrade\Upgrader0020 $upgrader */
     $upgrader = \Civi::service(Upgrader0020::class);
+    $upgrader->execute($this->ctx->log);
+
+    return TRUE;
+  }
+
+  public function upgrade_0021(): bool {
+    /** @var \Civi\Funding\Upgrade\Upgrader0021 $upgrader */
+    $upgrader = \Civi::service(Upgrader0021::class);
     $upgrader->execute($this->ctx->log);
 
     return TRUE;

--- a/Civi/Funding/ClearingProcess/Form/Validation/ClearingFormValidationResult.php
+++ b/Civi/Funding/ClearingProcess/Form/Validation/ClearingFormValidationResult.php
@@ -19,6 +19,7 @@ declare(strict_types = 1);
 
 namespace Civi\Funding\ClearingProcess\Form\Validation;
 
+use Civi\Funding\Form\MappedData\MappedDataLoader;
 use Systopia\JsonSchema\Tags\TaggedDataContainerInterface;
 
 /**
@@ -27,24 +28,31 @@ use Systopia\JsonSchema\Tags\TaggedDataContainerInterface;
 final class ClearingFormValidationResult {
 
   /**
-   * @phpstan-var array<string, non-empty-list<string>>
+   * @var array<string, non-empty-list<string>>
    */
   private array $errorMessages;
 
   /**
-   * @phpstan-var array<string, mixed>
+   * @var array<string, mixed>
    */
   private array $data;
+
+  /**
+   * @var array<string, mixed>
+   */
+  private array $mappedData;
 
   private TaggedDataContainerInterface $taggedData;
 
   /**
-   * @phpstan-param array<string, non-empty-list<string>> $errorMessages
-   * @phpstan-param array<string, mixed> $data
+   * @param array<string, non-empty-list<string>> $errorMessages
+   * @param array<string, mixed> $data
    */
   public function __construct(array $errorMessages, array $data, TaggedDataContainerInterface $taggedData) {
     $this->errorMessages = $errorMessages;
     $this->data = $data;
+    $mappedDataLoader = new MappedDataLoader();
+    $this->mappedData = $mappedDataLoader->getMappedData($taggedData);
     $this->taggedData = $taggedData;
   }
 
@@ -65,10 +73,17 @@ final class ClearingFormValidationResult {
   }
 
   /**
-   * @phpstan-return array<string, mixed>
+   * @return array<string, mixed>
    */
   public function getData(): array {
     return $this->data;
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function getMappedData(): array {
+    return $this->mappedData;
   }
 
   public function getTaggedData(): TaggedDataContainerInterface {

--- a/Civi/Funding/ClearingProcess/Handler/ClearingFormSubmitHandler.php
+++ b/Civi/Funding/ClearingProcess/Handler/ClearingFormSubmitHandler.php
@@ -32,6 +32,7 @@ use Civi\Funding\ClearingProcess\Handler\Helper\ClearingCostItemsFormDataPersist
 use Civi\Funding\ClearingProcess\Handler\Helper\ClearingResourcesItemsFormDataPersister;
 use Civi\Funding\Entity\ClearingProcessEntityBundle;
 use Civi\Funding\ExternalFile\TaggedExternalFilePersister;
+use Webmozart\Assert\Assert;
 
 /**
  * @phpstan-import-type clearingFormDataT from \Civi\Funding\ClearingProcess\Form\ClearingFormGenerator
@@ -118,6 +119,19 @@ final class ClearingFormSubmitHandler implements ClearingFormSubmitHandlerInterf
         /** @phpstan-var clearingFormDataT $data */
 
         $clearingProcess->setReportData($data['reportData'] ?? []);
+
+        $mappedData = $validationResult->getMappedData();
+        if (isset($mappedData['start_date'])) {
+          Assert::string($mappedData['start_date']);
+          $clearingProcess->setStartDate(new \DateTime($mappedData['start_date']));
+        }
+        if (isset($mappedData['end_date'])) {
+          Assert::string($mappedData['end_date']);
+          $clearingProcess->setEndDate(new \DateTime($mappedData['end_date']));
+        }
+        // Map custom fields.
+        // @phpstan-ignore argument.type
+        $clearingProcess->setValues($clearingProcess->toArray() + $validationResult->getMappedData());
       }
     }
 

--- a/Civi/Funding/Upgrade/Upgrader0021.php
+++ b/Civi/Funding/Upgrade/Upgrader0021.php
@@ -1,0 +1,79 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Funding\Upgrade;
+
+use Civi\Api4\FundingClearingProcess;
+use Civi\Funding\FundingCaseTypes\AuL\IJB\IJBConstants;
+use Civi\Funding\FundingCaseTypes\AuL\SammelantragKurs\KursConstants;
+use Civi\Funding\FundingCaseTypes\AuL\SonstigeAktivitaet\AVK1Constants;
+use Civi\RemoteTools\Api4\Api4Interface;
+
+final class Upgrader0021 implements UpgraderInterface {
+
+  private Api4Interface $api4;
+
+  public function __construct(Api4Interface $api4) {
+    $this->api4 = $api4;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function execute(\Log $log): void {
+    $log->info('Set ClearingProcess start and end date');
+
+    $clearingProcesses = $this->api4->execute('FundingClearingProcess', 'get', [
+      'select' => [
+        'id',
+        'report_data',
+      ],
+      'where' => [
+        ['status', '!=', 'not-started'],
+        [
+          'application_process_id.funding_case_id.funding_case_type_id.name',
+          'IN',
+          [
+            AVK1Constants::FUNDING_CASE_TYPE_NAME,
+            IJBConstants::FUNDING_CASE_TYPE_NAME,
+            KursConstants::FUNDING_CASE_TYPE_NAME,
+          ],
+        ],
+      ],
+    ]);
+
+    /** @phpstan-var array{id: int, report_data: array<string, mixed>} $clearingProcess */
+    foreach ($clearingProcesses as $clearingProcess) {
+      /** @phpstan-var list<array{beginn: string, ende: string}> $dateRanges */
+      // @phpstan-ignore offsetAccess.nonOffsetAccessible
+      $dateRanges = $clearingProcess['report_data']['grunddaten']['zeitraeume'] ?? [];
+      $startDate = $dateRanges[0]['beginn'] ?? NULL;
+      $endDate = end($dateRanges)['ende'] ?? NULL;
+
+      if (NULL !== $startDate || NULL !== $endDate) {
+        $this->api4->updateEntity(FundingClearingProcess::getEntityName(), $clearingProcess['id'], [
+          'start_date' => $startDate,
+          'end_date' => $endDate,
+        ]);
+      }
+    }
+  }
+
+}

--- a/tests/phpunit/Civi/Funding/Api4/Action/FundingClearingProcess/GetFormActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/FundingClearingProcess/GetFormActionTest.php
@@ -77,6 +77,13 @@ final class GetFormActionTest extends AbstractFundingHeadlessTestCase {
           'format' => 'uri',
           '$tag' => 'externalFile',
         ],
+        'date_of_begin' => [
+          'type' => 'string',
+          'format' => 'date-time',
+          '$tag' => [
+            'mapToField' => ['fieldName' => 'start_date'],
+          ],
+        ],
       ],
     ], $result['jsonSchema']['properties']['reportData']);
 

--- a/tests/phpunit/Civi/Funding/Api4/Action/FundingClearingProcess/SubmitFormActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/FundingClearingProcess/SubmitFormActionTest.php
@@ -131,8 +131,9 @@ final class SubmitFormActionTest extends AbstractFundingHeadlessTestCase {
       [ClearingProcessPermissions::REVIEW_AMEND],
     );
 
+    $clearingProcessId = $this->clearingProcessBundle->getClearingProcess()->getId();
     $result = FundingClearingProcess::submitForm()
-      ->setId($this->clearingProcessBundle->getClearingProcess()->getId())
+      ->setId($clearingProcessId)
       ->setData([
         'costItems' => [
           $this->costItem->getId() => [
@@ -166,7 +167,10 @@ final class SubmitFormActionTest extends AbstractFundingHeadlessTestCase {
             ],
           ],
         ],
-        'reportData' => ['foo' => 'bar'],
+        'reportData' => [
+          'foo' => 'bar',
+          'date_of_begin' => '2000-01-02T03:04:05',
+        ],
         '_action' => 'update',
       ])
       ->execute()
@@ -180,7 +184,7 @@ final class SubmitFormActionTest extends AbstractFundingHeadlessTestCase {
 
     static::assertEquals([
       'id' => $result['data']['costItems'][$this->costItem->getId()]['records'][0]['_id'],
-      'clearing_process_id' => $this->clearingProcessBundle->getClearingProcess()->getId(),
+      'clearing_process_id' => $clearingProcessId,
       'application_cost_item_id' => $this->costItem->getId(),
       'status' => 'new',
       'file_id' => NULL,
@@ -197,7 +201,7 @@ final class SubmitFormActionTest extends AbstractFundingHeadlessTestCase {
 
     static::assertEquals([
       'id' => $result['data']['resourcesItems'][$this->resourcesItem->getId()]['records'][0]['_id'],
-      'clearing_process_id' => $this->clearingProcessBundle->getClearingProcess()->getId(),
+      'clearing_process_id' => $clearingProcessId,
       'app_resources_item_id' => $this->resourcesItem->getId(),
       'status' => 'new',
       'file_id' => NULL,
@@ -211,6 +215,16 @@ final class SubmitFormActionTest extends AbstractFundingHeadlessTestCase {
       'properties' => NULL,
       'form_key' => $this->resourcesItem->getId() . '/0',
     ], FundingClearingResourcesItem::get(FALSE)->execute()->single());
+
+    // date_of_begin should be mapped to start_date.
+    static::assertSame(
+      '2000-01-02 03:04:05',
+      FundingClearingProcess::get(FALSE)
+        ->addWhere('id', '=', $clearingProcessId)
+        ->addSelect('start_date')
+        ->execute()
+        ->single()['start_date']
+    );
   }
 
   public function testAddClearingItemWithoutAmendPermission(): void {

--- a/tests/phpunit/Civi/Funding/Api4/Action/RemoteFundingClearingProcess/GetFormActionTest.php
+++ b/tests/phpunit/Civi/Funding/Api4/Action/RemoteFundingClearingProcess/GetFormActionTest.php
@@ -78,6 +78,13 @@ final class GetFormActionTest extends AbstractRemoteFundingHeadlessTestCase {
           'format' => 'uri',
           '$tag' => 'externalFile',
         ],
+        'date_of_begin' => [
+          'type' => 'string',
+          'format' => 'date-time',
+          '$tag' => [
+            'mapToField' => ['fieldName' => 'start_date'],
+          ],
+        ],
       ],
     ], $result['jsonSchema']['properties']['reportData']);
 

--- a/tests/phpunit/Civi/Funding/Fixtures/ApplicationProcessBundleFixture.php
+++ b/tests/phpunit/Civi/Funding/Fixtures/ApplicationProcessBundleFixture.php
@@ -26,7 +26,7 @@ final class ApplicationProcessBundleFixture {
   /**
    * @phpstan-param array<string, mixed> $applicationProcessValues
    * @phpstan-param array<string, mixed> $fundingCaseValues
-   * @phpstan-param array<string, scalar> $fundingCaseTypeValues
+   * @phpstan-param array<string, mixed> $fundingCaseTypeValues
    * @phpstan-param array<string, scalar|null> $fundingProgramValues
    *
    * @throws \CRM_Core_Exception

--- a/tests/phpunit/Civi/Funding/Fixtures/ClearingProcessBundleFixture.php
+++ b/tests/phpunit/Civi/Funding/Fixtures/ClearingProcessBundleFixture.php
@@ -24,16 +24,27 @@ use Civi\Funding\Entity\ClearingProcessEntityBundle;
 final class ClearingProcessBundleFixture {
 
   /**
-   * @phpstan-param array<string, mixed> $clearingProcessValues
-   * @phpstan-param array<string, mixed> $applicationProcessValues
+   * @param array<string, mixed> $clearingProcessValues
+   * @param array<string, mixed> $applicationProcessValues
+   * @param array<string, mixed> $fundingCaseValues
+   * @param array<string, mixed> $fundingCaseTypeValues
+   * @param array<string, scalar|null> $fundingProgramValues
    *
    * @throws \CRM_Core_Exception
    */
   public static function create(
     array $clearingProcessValues = [],
-    array $applicationProcessValues = []
+    array $applicationProcessValues = [],
+    array $fundingCaseValues = [],
+    array $fundingCaseTypeValues = [],
+    array $fundingProgramValues = []
   ): ClearingProcessEntityBundle {
-    $applicationProcessBundle = ApplicationProcessBundleFixture::create($applicationProcessValues);
+    $applicationProcessBundle = ApplicationProcessBundleFixture::create(
+      $applicationProcessValues,
+      $fundingCaseValues,
+      $fundingCaseTypeValues,
+      $fundingProgramValues
+    );
     $clearingProcess = ClearingProcessFixture::addFixture(
       $applicationProcessBundle->getApplicationProcess()->getId(),
       $clearingProcessValues

--- a/tests/phpunit/Civi/Funding/Fixtures/FundingCaseBundleFixture.php
+++ b/tests/phpunit/Civi/Funding/Fixtures/FundingCaseBundleFixture.php
@@ -25,7 +25,7 @@ final class FundingCaseBundleFixture {
 
   /**
    * @phpstan-param array<string, mixed> $fundingCaseValues
-   * @phpstan-param array<string, scalar> $fundingCaseTypeValues
+   * @phpstan-param array<string, mixed> $fundingCaseTypeValues
    * @phpstan-param array<string, scalar|null> $fundingProgramValues
    *
    * @throws \CRM_Core_Exception

--- a/tests/phpunit/Civi/Funding/Mock/FundingCaseType/Clearing/TestReportFormFactory.php
+++ b/tests/phpunit/Civi/Funding/Mock/FundingCaseType/Clearing/TestReportFormFactory.php
@@ -29,6 +29,7 @@ use Civi\Funding\Mock\FundingCaseType\Traits\TestSupportedFundingCaseTypesTrait;
 use Civi\RemoteTools\JsonForms\JsonFormsControl;
 use Civi\RemoteTools\JsonForms\JsonFormsMarkup;
 use Civi\RemoteTools\JsonForms\Layout\JsonFormsGroup;
+use Civi\RemoteTools\JsonSchema\JsonSchema;
 use Civi\RemoteTools\JsonSchema\JsonSchemaObject;
 use Civi\RemoteTools\JsonSchema\JsonSchemaString;
 
@@ -54,6 +55,10 @@ final class TestReportFormFactory implements ReportFormFactoryInterface {
         'file' => new JsonSchemaString([
           'format' => 'uri',
           '$tag' => 'externalFile',
+        ]),
+        'date_of_begin' => new JsonSchemaString([
+          'format' => 'date-time',
+          '$tag' => JsonSchema::fromArray(['mapToField' => ['fieldName' => 'start_date']]),
         ]),
       ]),
     ]);

--- a/tests/phpunit/Civi/Funding/Upgrade/Upgrader0021Test.php
+++ b/tests/phpunit/Civi/Funding/Upgrade/Upgrader0021Test.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Funding\Upgrade;
+
+use Civi\Api4\FundingClearingProcess;
+use Civi\Funding\Fixtures\ClearingProcessBundleFixture;
+use Civi\Funding\FundingCaseTypes\AuL\SonstigeAktivitaet\AVK1Constants;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\Funding\Upgrade\Upgrader0021
+ */
+final class Upgrader0021Test extends TestCase {
+
+  public function testExecute(): void {
+    $clearingProcessBundle = ClearingProcessBundleFixture::create(
+      [
+        'report_data' => [
+          'grunddaten' => [
+            'zeitraeume' => [
+              [
+                'beginn' => '2024-03-04',
+                'ende' => '2024-03-05',
+              ],
+              [
+                'beginn' => '2024-04-04',
+                'ende' => '2024-04-05',
+              ],
+            ],
+          ],
+        ],
+      ],
+      fundingCaseTypeValues: ['name' => AVK1Constants::FUNDING_CASE_TYPE_NAME],
+    );
+
+    /** @var \Civi\Funding\Upgrade\Upgrader0021 $upgrader */
+    $upgrader = \Civi::service(Upgrader0021::class);
+
+    $upgrader->execute(new \Log_null('test'));
+
+    $clearingProcess = FundingClearingProcess::get(FALSE)
+      ->addSelect('start_date', 'end_date')
+      ->addWhere('id', '=', $clearingProcessBundle->getClearingProcess()->getId())
+      ->execute()
+      ->single();
+
+    static::assertSame('2024-03-04 00:00:00', $clearingProcess['start_date']);
+    static::assertSame('2024-04-05 00:00:00', $clearingProcess['end_date']);
+  }
+
+}


### PR DESCRIPTION
Add support for the tag `mapToField` in clearing forms like in application forms.

This was actually meant to be available for #447 so we need another upgrade step. 

systopia-reference: 32669