### PR TITLE
Personalkosten: Fix error when no file is given on action with limited validation

### DIFF
--- a/Civi/Funding/FundingCaseTypes/AuL/Personalkosten/Application/Data/PersonalkostenApplicationFormFilesFactory.php
+++ b/Civi/Funding/FundingCaseTypes/AuL/Personalkosten/Application/Data/PersonalkostenApplicationFormFilesFactory.php
@@ -29,9 +29,10 @@ use Webmozart\Assert\Assert;
 /**
  * @phpstan-type dokumenteT list<array{
  *   _identifier?: string,
- *   datei: string,
+ *   datei?: string,
  *   beschreibung: string,
  * }>
+ * On submit with limited validation (e.g. acion "save") "datei" may be missing.
  */
 final class PersonalkostenApplicationFormFilesFactory implements ApplicationFormFilesFactoryInterface {
 
@@ -60,6 +61,10 @@ final class PersonalkostenApplicationFormFilesFactory implements ApplicationForm
     /** @phpstan-var dokumenteT $dokumente */
     $dokumente = $requestData['dokumente'];
     foreach ($dokumente as $dokument) {
+      if (!array_key_exists('datei', $dokument)) {
+        continue;
+      }
+
       Assert::keyExists($dokument, '_identifier');
       $files[] = new FundingFormFile(
         $dokument['datei'],

--- a/Civi/Funding/FundingCaseTypes/AuL/Personalkosten/Application/JsonSchema/PersonalkostenApplicationJsonSchema.php
+++ b/Civi/Funding/FundingCaseTypes/AuL/Personalkosten/Application/JsonSchema/PersonalkostenApplicationJsonSchema.php
@@ -130,7 +130,7 @@ final class PersonalkostenApplicationJsonSchema extends JsonSchemaObject {
         ['$tag' => JsonSchema::fromArray(['mapToField' => ['fieldName' => 'amount_requested']])]
       ),
       'empfaenger' => new JsonSchemaRecipient($possibleRecipients),
-      'dokumente' => new PersonalkostenDokumenteJsonSchema(),
+      'dokumente' => new PersonalkostenDokumenteJsonSchema($limitedValidationActions),
     ];
 
     $required = array_keys($properties);

--- a/Civi/Funding/FundingCaseTypes/AuL/Personalkosten/Application/JsonSchema/PersonalkostenDokumenteJsonSchema.php
+++ b/Civi/Funding/FundingCaseTypes/AuL/Personalkosten/Application/JsonSchema/PersonalkostenDokumenteJsonSchema.php
@@ -20,22 +20,48 @@ declare(strict_types = 1);
 
 namespace Civi\Funding\FundingCaseTypes\AuL\Personalkosten\Application\JsonSchema;
 
+use Civi\RemoteTools\JsonSchema\JsonSchema;
 use Civi\RemoteTools\JsonSchema\JsonSchemaArray;
+use Civi\RemoteTools\JsonSchema\JsonSchemaDataPointer;
 use Civi\RemoteTools\JsonSchema\JsonSchemaObject;
 use Civi\RemoteTools\JsonSchema\JsonSchemaString;
 
 final class PersonalkostenDokumenteJsonSchema extends JsonSchemaArray {
 
-  public function __construct() {
+  /**
+   * @param list<string> $limitedValidationActions
+   */
+  public function __construct(array $limitedValidationActions) {
     parent::__construct(
       new JsonSchemaObject(
         [
           '_identifier' => new JsonSchemaString(['readonly' => TRUE]),
-          'datei' => new JsonSchemaString(['format' => 'uri']),
-          'beschreibung' => new JsonSchemaString(),
+          'datei' => new JsonSchemaString([
+            'format' => 'uri',
+            'maxLength' => 255,
+          ]),
+          'beschreibung' => new JsonSchemaString(['minLength' => 1, 'maxLength' => 255]),
         ],
-        ['required' => ['datei', 'beschreibung']]
-      ), ['minItems' => 1]
+        [
+          'required' => ['datei', 'beschreibung'],
+          // If "beschreibung" is not empty a "datei" is required so it's
+          // possible to persist the file together with "beschreibung".
+          '$limitValidation' => JsonSchema::fromArray([
+            'condition' => [
+              'evaluate' => [
+                'expression' => 'action in limitedValidationActions && beschreibung == ""',
+                'variables' => [
+                  'action' => new JsonSchemaDataPointer('/_action', ''),
+                  'limitedValidationActions' => $limitedValidationActions,
+                  'beschreibung' => new JsonSchemaDataPointer('0/beschreibung'),
+                ],
+              ],
+            ],
+          ]),
+        ]
+      ), [
+        'minItems' => 1,
+      ]
     );
   }
 


### PR DESCRIPTION
Previously `NULL` was given in
`\Civi\Funding\Form\FundingFormFile::__construct()` as `$uri` which is required do be a string, if no file was selected and an action with limited validation (e.g. "save") was used.

systopia-reference: 33979